### PR TITLE
make token optional for job start

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ bespin jobs list
 ```
 
 ### Start running the job
-Start running a job using the token "run-job-token1"
+Start running a job
 ```
-bespin jobs start 1 --token run-job-token1
+bespin jobs start 1
 ```

--- a/bespin/argparse.py
+++ b/bespin/argparse.py
@@ -62,7 +62,7 @@ class ArgParser(object):
         start_jobs_parser = jobs_subparser.add_parser('start', description='start job')
         start_jobs_parser.set_defaults(func=self._run_start_job)
         start_jobs_parser.add_argument('job_id', type=int)
-        start_jobs_parser.add_argument('--token', type=str, required=True)
+        start_jobs_parser.add_argument('--token', type=str, required=False)
 
         cancel_jobs_parser = jobs_subparser.add_parser('cancel', description='cancel job')
         cancel_jobs_parser.set_defaults(func=self._run_cancel_job)

--- a/bespin/argparse.py
+++ b/bespin/argparse.py
@@ -62,7 +62,7 @@ class ArgParser(object):
         start_jobs_parser = jobs_subparser.add_parser('start', description='start job')
         start_jobs_parser.set_defaults(func=self._run_start_job)
         start_jobs_parser.add_argument('job_id', type=int)
-        start_jobs_parser.add_argument('--token', type=str, required=False)
+        start_jobs_parser.add_argument('--token', type=str)
 
         cancel_jobs_parser = jobs_subparser.add_parser('cancel', description='cancel job')
         cancel_jobs_parser.set_defaults(func=self._run_cancel_job)

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -91,7 +91,7 @@ class Commands(object):
         job = job_file.create_job(api)
         job_id = job['id']
         print("Created job {}".format(job_id))
-        print("To start this job run `bespin jobs start {} --token _RUN_JOB_TOKEN_ >` .".format(job_id))
+        print("To start this job run `bespin jobs start {}` .".format(job_id))
 
     def start_job(self, job_id, token=None):
         """

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -23,6 +23,10 @@ class ArgParserTestCase(TestCase):
         self.target_object.create_job.assert_called()
 
     def test_start_job(self):
+        self.arg_parser.parse_and_run_commands(["jobs", "start", "123"])
+        self.target_object.start_job.assert_called_with(123, None)
+
+    def test_start_job_with_optional_token(self):
         self.arg_parser.parse_and_run_commands(["jobs", "start", "123", "--token", "secret"])
         self.target_object.start_job.assert_called_with(123, "secret")
 

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -66,7 +66,7 @@ class CommandsTestCase(TestCase):
         mock_job_file_loader.assert_called_with(mock_infile)
         mock_print.assert_has_calls([
             call("Created job 1"),
-            call("To start this job run `bespin jobs start 1 --token _RUN_JOB_TOKEN_ >` .")])
+            call("To start this job run `bespin jobs start 1` .")])
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')


### PR DESCRIPTION
Make the token optional argument for `bespin jobs start` command to match up with changes from https://github.com/Duke-GCB/bespin-api/issues/139.