### PR TITLE
add placeholder value for FASTQReadPairType

### DIFF
--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -30,9 +30,19 @@ USER_PLACEHOLDER_DICT = {
             "class": "File",
             "path": FILE_PLACEHOLDER
         }
+    },
+    'FASTQReadPairType': {
+        "name": STRING_VALUE_PLACEHOLDER,
+        "read1_files": [{
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        }],
+        "read2_files": [{
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        }]
     }
 }
-
 
 class Commands(object):
     """


### PR DESCRIPTION
Changes to help a user setup the new exomeseq workflow by adding boilerplate example.
Should match up with [FASTQReadPairType in bespin-cwl](https://github.com/Duke-GCB/bespin-cwl/blob/10ef0d6ad1db4e782df66e914e2bee66b898afbb/types/bespin-types.yml#L3-L11)


NOTE: #3 may move this boilerplate out of this repository.