### PR TITLE
add --all option to workflows list

### DIFF
--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -40,6 +40,8 @@ class ArgParser(object):
         jobs_subparser = jobs_parser.add_subparsers()
 
         list_jobs_parser = jobs_subparser.add_parser('list', description='list workflows')
+        list_jobs_parser.add_argument('-a', '--all', action='store_true',
+                                      help='show all workflow versions instead of just the most recent.')
         list_jobs_parser.set_defaults(func=self._run_list_workflows)
 
     def _create_job_parser(self, subparsers):
@@ -79,8 +81,8 @@ class ArgParser(object):
     def _run_list_jobs(self, _):
         self.target_object.jobs_list()
 
-    def _run_list_workflows(self, _):
-        self.target_object.workflows_list()
+    def _run_list_workflows(self, args):
+        self.target_object.workflows_list(all_versions=args.all)
 
     def _run_init_job(self, args):
         self.target_object.init_job(args.tag, args.outfile)

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -10,9 +10,17 @@ class ArgParserTestCase(TestCase):
         self.target_object = Mock()
         self.arg_parser = ArgParser(version_str='1.0', target_object=self.target_object)
 
-    def test_workflows_list(self):
+    def test_workflows_list_current_versions(self):
         self.arg_parser.parse_and_run_commands(["workflows", "list"])
-        self.target_object.workflows_list.assert_called()
+        self.target_object.workflows_list.assert_called_with(all_versions=False)
+
+    def test_workflows_list_all_versions(self):
+        self.arg_parser.parse_and_run_commands(["workflows", "list", "--all"])
+        self.target_object.workflows_list.assert_called_with(all_versions=True)
+
+    def test_workflows_list_all_versions_short_flag(self):
+        self.arg_parser.parse_and_run_commands(["workflows", "list", "-a"])
+        self.target_object.workflows_list.assert_called_with(all_versions=True)
 
     def test_init_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "init", "--tag", "exome/v1/human"])


### PR DESCRIPTION
Adds option to show all workflow versions to the workflows list
command. Users can use either `-a` or `--all` with the `bespin workflows list` command.

Fixes #14