### PR TITLE
specify file input sizes based on DukeDS sizes

### DIFF
--- a/bespin/api.py
+++ b/bespin/api.py
@@ -103,7 +103,7 @@ class BespinApi(object):
         return self._post_request('/job-file-stage-groups/', {})
 
     def dds_job_input_files_post(self, project_id, file_id, destination_path, sequence_group, sequence,
-                                 dds_user_credentials, stage_group_id):
+                                 dds_user_credentials, stage_group_id, size):
         data = {
             "project_id": project_id,
             "file_id": file_id,
@@ -111,7 +111,8 @@ class BespinApi(object):
             "sequence_group": sequence_group,
             "sequence": sequence,
             "dds_user_credentials": dds_user_credentials,
-            "stage_group": stage_group_id
+            "stage_group": stage_group_id,
+            "size": size,
         }
         return self._post_request('/dds-job-input-files/', data)
 

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -288,8 +288,10 @@ class JobFile(object):
         dds_project_ids = set()
         sequence = 0
         for dds_file, path in self.get_dds_files_details():
+            file_size = dds_file.current_version['upload']['size']
             api.dds_job_input_files_post(dds_file.project_id, dds_file.id, path, 0, sequence,
-                                         dds_user_credential['id'], stage_group_id=stage_group['id'])
+                                         dds_user_credential['id'], stage_group_id=stage_group['id'],
+                                         size=file_size)
             sequence += 1
             dds_project_ids.add(dds_file.project_id)
         user_job_order_json = self.create_user_job_order_json()

--- a/bespin/dukeds.py
+++ b/bespin/dukeds.py
@@ -8,6 +8,7 @@ INVALID_DUKEDS_FILE_PATH_MSG = "Invalid DukeDS file path ({})"
 DUKEDS_FILE_PATH_MISSING_PREFIX = INVALID_DUKEDS_FILE_PATH_MSG.format("missing prefix")
 DUKEDS_FILE_PATH_MISSING_SLASH = INVALID_DUKEDS_FILE_PATH_MSG.format("missing / between project and file path")
 
+
 class DDSFileUtil(object):
     def __init__(self):
         self.client = Client()

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -145,7 +145,8 @@ class BespinApiTestCase(TestCase):
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
         dds_input_file = api.dds_job_input_files_post(project_id='123', file_id='456', destination_path='data.txt',
                                                       sequence_group=1, sequence=2,
-                                                      dds_user_credentials=4, stage_group_id=5)
+                                                      dds_user_credentials=4, stage_group_id=5,
+                                                      size=1000)
 
         self.assertEqual(dds_input_file, 'dds-job-input-file1')
         expected_json = {
@@ -155,7 +156,8 @@ class BespinApiTestCase(TestCase):
             'sequence_group': 1,
             'sequence': 2,
             'dds_user_credentials': 4,
-            'stage_group': 5
+            'stage_group': 5,
+            'size': 1000,
         }
         mock_requests.post.assert_called_with('someurl/dds-job-input-files/', headers=self.expected_headers,
                                               json=expected_json)

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -336,14 +336,15 @@ class JobFileTestCase(TestCase):
             'myint': 555
         })
         job_file.get_dds_files_details = Mock()
-        mock_file = Mock(project_id=666)
+        mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
         mock_file.id = 777
         job_file.get_dds_files_details.return_value = [[mock_file, 'somepath']]
 
         job_file.create_job(mock_api)
 
         mock_api.questionnaires_list.assert_called_with(tag='sometag')
-        mock_api.dds_job_input_files_post.assert_called_with(666, 777, 'somepath', 0, 0, 111, stage_group_id=333)
+        mock_api.dds_job_input_files_post.assert_called_with(666, 777, 'somepath', 0, 0, 111, stage_group_id=333,
+                                                             size=4002)
         json_payload = '{"myfile": {"class": "File", "path": "dds_project_somepath.txt"}, "myint": 555}'
         mock_api.job_answer_set_post.assert_called_with('myjob', '001', json_payload, 222, 333)
         mock_api.job_answer_set_create_job.assert_called_with(444)


### PR DESCRIPTION
When posting input files to bespin-api pass file sizes.
This enables accurate volume sizing for the job.
Uses size from DukeDS API file response.

Fixes #13