### PR TITLE
Adds dry run option to jobs create

### DIFF
--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -63,6 +63,8 @@ class ArgParser(object):
 
         submit_jobs_parser = jobs_subparser.add_parser('create',
                                                        description="create job using 'infile' from init command")
+        submit_jobs_parser.add_argument('--dry-run', action='store_true',
+                                 help='Do not create a job, instead check the inputs for validity.')
         submit_jobs_parser.set_defaults(func=self._run_create_job)
         submit_jobs_parser.add_argument('infile', type=argparse.FileType('r'), help='file created by init command')
 
@@ -96,7 +98,7 @@ class ArgParser(object):
         self.target_object.init_job(args.tag, args.outfile)
 
     def _run_create_job(self, args):
-        self.target_object.create_job(args.infile)
+        self.target_object.create_job(args.infile, args.dry_run)
 
     def _run_start_job(self, args):
         self.target_object.start_job(args.job_id, args.token)

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -320,10 +320,9 @@ class JobFile(object):
         return job
 
     def verify_job(self, api):
-        workflow_configuration = self.read_workflow_configuration(api)
-        for dds_file, path in self.get_dds_files_details():
-            file_size = dds_file.current_version['upload']['size']
-        user_job_order = self.create_user_job_order()
+        self.read_workflow_configuration(api)  # workflow configuration must exist
+        self.get_dds_files_details()  # DukeDS input files must exist
+        self.create_user_job_order()  # verify that we can generate a job order
         print("Job file is valid.")
 
 

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from bespin.config import ConfigFile
 from bespin.api import BespinApi
-from bespin.exceptions import IncompleteJobFileException
+from bespin.exceptions import IncompleteJobFileException, WorkflowConfigurationNotFoundException
 from bespin.dukeds import DDSFileUtil
 from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
 from tabulate import tabulate
@@ -98,18 +98,22 @@ class Commands(object):
             print("Wrote job file {}.".format(outfile.name))
             print("Edit this file filling in TODO fields then run `bespin jobs create {}` .".format(outfile.name))
 
-    def create_job(self, infile):
+    def create_job(self, infile, dry_run):
         """
         Create a job based on an input job file (possibly created via init_job)
         Prints out job id.
         :param infile: file: input file to use for creating a job
+        :param dry_run: boolean: when True do not actually create a job just validate the input
         """
         api = self._create_api()
         job_file = JobFileLoader(infile).create_job_file()
-        job = job_file.create_job(api)
-        job_id = job['id']
-        print("Created job {}".format(job_id))
-        print("To start this job run `bespin jobs start {}` .".format(job_id))
+        if dry_run:
+            job_file.verify_job(api)
+        else:
+            job = job_file.create_job(api)
+            job_id = job['id']
+            print("Created job {}".format(job_id))
+            print("To start this job run `bespin jobs start {}` .".format(job_id))
 
     def start_job(self, job_id, token=None):
         """
@@ -281,6 +285,14 @@ class JobFile(object):
         job_order_details.walk(self.job_order)
         return job_order_details.dds_files
 
+    def read_workflow_configuration(self, api):
+        workflow_configurations = api.workflow_configurations_list(tag=self.workflow_tag)
+        if workflow_configurations:
+            return workflow_configurations[0]
+        raise WorkflowConfigurationNotFoundException(
+            "Unable to find workflow configuration for tag {}".format(self.workflow_tag)
+        )
+
     def create_job(self, api):
         """
         Create a job using the passed on api
@@ -288,7 +300,7 @@ class JobFile(object):
         :return: dict: job dictionary returned from bespin api
         """
         dds_user_credential = api.dds_user_credentials_list()[0]
-        workflow_configuration = api.workflow_configurations_list(tag=self.workflow_tag)[0]
+        workflow_configuration = self.read_workflow_configuration(api)
         stage_group = api.stage_group_post()
         dds_project_ids = set()
         sequence = 0
@@ -306,6 +318,13 @@ class JobFile(object):
         for project_id in dds_project_ids:
             dds_file_util.give_download_permissions(project_id, dds_user_credential['dds_id'])
         return job
+
+    def verify_job(self, api):
+        workflow_configuration = self.read_workflow_configuration(api)
+        for dds_file, path in self.get_dds_files_details():
+            file_size = dds_file.current_version['upload']['size']
+        user_job_order = self.create_user_job_order()
+        print("Job file is valid.")
 
 
 class JobFileLoader(object):

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -109,6 +109,7 @@ class Commands(object):
         job_file = JobFileLoader(infile).create_job_file()
         if dry_run:
             job_file.verify_job(api)
+            print("Job file is valid.")
         else:
             job = job_file.create_job(api)
             job_id = job['id']
@@ -323,7 +324,6 @@ class JobFile(object):
         self.read_workflow_configuration(api)  # workflow configuration must exist
         self.get_dds_files_details()  # DukeDS input files must exist
         self.create_user_job_order()  # verify that we can generate a job order
-        print("Job file is valid.")
 
 
 class JobFileLoader(object):

--- a/bespin/exceptions.py
+++ b/bespin/exceptions.py
@@ -22,3 +22,6 @@ class ProjectDoesNotExistException(UserInputException):
 class JobDoesNotExistException(UserInputException):
     pass
 
+
+class WorkflowConfigurationNotFoundException(UserInputException):
+    pass

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from bespin.argparser import ArgParser
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 import sys
 
 
@@ -32,7 +32,11 @@ class ArgParserTestCase(TestCase):
 
     def test_create_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py"])
-        self.target_object.create_job.assert_called()
+        self.target_object.create_job.assert_called_with(ANY, False)
+
+    def test_create_job_dry_run(self):
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run"])
+        self.target_object.create_job.assert_called_with(ANY, True)
 
     def test_start_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "start", "123"])

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -79,12 +79,24 @@ class CommandsTestCase(TestCase):
         mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'id': 1}
 
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.create_job(infile=mock_infile)
+        commands.create_job(infile=mock_infile, dry_run=False)
 
         mock_job_file_loader.assert_called_with(mock_infile)
         mock_print.assert_has_calls([
             call("Created job 1"),
             call("To start this job run `bespin jobs start 1` .")])
+
+    @patch('bespin.commands.ConfigFile')
+    @patch('bespin.commands.BespinApi')
+    @patch('bespin.commands.JobFileLoader')
+    @patch('bespin.commands.print')
+    def test_create_job_dry_run(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
+        mock_infile = Mock()
+        commands = Commands(self.version_str, self.user_agent_str)
+        commands.create_job(infile=mock_infile, dry_run=True)
+        mock_job_file_loader.assert_called_with(mock_infile)
+        mock_job_file = mock_job_file_loader.return_value.create_job_file.return_value
+        mock_job_file.verify_job.assert_called_with(mock_bespin_api.return_value)
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -101,6 +101,7 @@ class CommandsTestCase(TestCase):
         mock_job_file_loader.assert_called_with(mock_infile)
         mock_job_file = mock_job_file_loader.return_value.create_job_file.return_value
         mock_job_file.verify_job.assert_called_with(mock_bespin_api.return_value)
+        mock_print.assert_called_with('Job file is valid.')
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')


### PR DESCRIPTION
Adds an optional argument to let a user test to see if their job file is valid and `jobs create` is expected to succeed:
`bespin jobs create --dry-run <jobfile>`