### PR TITLE
simplify command line + workflow/etc creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ params:
   sequences:
     class: File
     path: dds://TODO_PROJECT_NAME/TODO_FILE_PATH
-workflow_tag: qime2_step1/1/human
+tag: qime2_step1/1/human
 ```
 User will replace all TODO fields with actual values.
 

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Command line client for Bespin
 ### Find workflow tag
 List workflows:
 ```
-bespin workflows list
+bespin workflow list
 ```
 Output:
 ```
-  Id  Name                          Latest Version Tag
-----  ----------------------------  -------------------------
-   1  QIIME2 Step 1                 qime2_step1/1/human
-   2  QIIME2 Step 2 (DADA2 option)  qime2_step2_dada2/1/human
+bespin workflow list
+  Id  Name                     Job Template Tag
+----  -----------------------  ------------------------------------------
+   1  WES GATK4 Preprocessing  wes-gatk4-preprocessing/v1/b37-human-xgen
 ```
 
 
 ### Init job file
 ```
-bespin jobs init --tag qime2_step1/1/human --outfile job1.yml
+bespin job-template create wes-gatk4-preprocessing/v1/b37-human-xgen --outfile job1.yml
 ```
 Output:
 ```
@@ -32,27 +32,26 @@ Edit this file filling in TODO fields then run `bespin job create job1.yml` .
 ### User edits job file
 Example job file:
 ```
-fund_code: TODO
-name: TODO
-params:
-  barcodes:
-    class: File
-    path: dds://TODO_PROJECT_NAME/TODO_FILE_PATH
-  metadata_barcodes_column: TODO
-  sample_metadata:
-    class: File
-    path: dds://TODO_PROJECT_NAME/TODO_FILE_PATH
-  sequences:
-    class: File
-    path: dds://TODO_PROJECT_NAME/TODO_FILE_PATH
-tag: qime2_step1/1/human
+fund_code: <String Value>
+job_order:
+  library: <String Value>
+  read_pair:
+    name: <String Value>
+    read1_files:
+    - class: File
+      path: dds://<Project Name>/<File Path>
+    read2_files:
+    - class: File
+      path: dds://<Project Name>/<File Path>
+name: <String Value>
+tag: wes-gatk4-preprocessing/v1/b37-human-xgen
 ```
 User will replace all TODO fields with actual values.
 
 
 ### Create job using job file
 ```
-bespin jobs create job1.yml
+bespin job create job1.yml
 ```
 Output:
 ```
@@ -61,18 +60,22 @@ Created job 1
 
 ### Check Status of the job
 ```
-bespin jobs list
+bespin job list
 ```
 Output:
 ```
-bespin jobs list
-  Id  Name    State    Step      Fund Code  Created           Last Updated
-----  ------  -------  ------  -----------  ----------------  ----------------
-   1  My Job  New                       1   2018-06-07 17:00  2018-06-07 17:00
+  Id  Name                      State    Step    Last Updated                   Elapsed Hours  Workflow Version Tag
+----  ------------------------  -------  ------  ---------------------------  ---------------  ---------------------------
+   1  My                        A                2018-11-15T17:02:44.224348Z                0  wes-gatk4-preprocessing/v1   
 ```
 
 ### Start running the job
 Start running a job
 ```
-bespin jobs start 1
+bespin job start 1
+```
+
+### Create and start a job in one step
+```
+bespin job run job1.yml
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ bespin workflow list
 ```
 Output:
 ```
-bespin workflow list
   Id  Name                     Job Template Tag
 ----  -----------------------  ------------------------------------------
    1  WES GATK4 Preprocessing  wes-gatk4-preprocessing/v1/b37-human-xgen

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Command line client for Bespin
 
 ## Example usage
 
-### Find workflow tag
+### Find job template tag
 List workflows:
 ```
 bespin workflow list
@@ -18,7 +18,7 @@ bespin workflow list
 ```
 
 
-### Init job file
+### Create job template file
 ```
 bespin job-template create wes-gatk4-preprocessing/v1/b37-human-xgen --outfile job1.yml
 ```
@@ -29,7 +29,7 @@ Edit this file filling in TODO fields then run `bespin job create job1.yml` .
 ```
 
 
-### User edits job file
+### User edits job template file
 Example job file:
 ```
 fund_code: <String Value>
@@ -49,7 +49,7 @@ tag: wes-gatk4-preprocessing/v1/b37-human-xgen
 User will replace all TODO fields with actual values.
 
 
-### Create job using job file
+### Create job using job template file
 ```
 bespin job create job1.yml
 ```

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -160,6 +160,18 @@ class BespinApi(object):
     def dds_user_credentials_list(self):
         return self._get_request('/dds-user-credentials/')
 
+    def get_share_groups(self, name=None):
+        url = '/share-groups/'
+        if name:
+            url += "?name={}".format(name)
+        return self._get_request(url)
+
+    def get_vm_strategies(self, name=None):
+        url = '/vm-strategies/'
+        if name:
+            url += "?name={}".format(name)
+        return self._get_request(url)
+
 
 class BespinException(Exception):
     pass

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -78,8 +78,21 @@ class BespinApi(object):
     def workflows_list(self):
         return self._get_request('/workflows/')
 
+    def workflow_get(self, workflow_id):
+        return self._get_request('/workflows/{}/'.format(workflow_id))
+
     def workflow_versions_list(self):
         return self._get_request('/workflow-versions/')
+
+    def workflow_versions_post(self, workflow, version_num, description, url, fields):
+        data = {
+            "workflow": workflow,
+            "version": version_num,
+            "description": description,
+            "url": url,
+            "fields": fields
+        }
+        return self._post_request('/admin/workflow-versions/', data)
 
     def workflow_version_get(self, workflow_version):
         return self._get_request('/workflow-versions/{}/'.format(workflow_version))
@@ -95,6 +108,17 @@ class BespinApi(object):
                     url += "&"
                 url += "tag={}".format(tag)
         return self._get_request(url)
+
+    def workflow_configurations_post(self, name, workflow, default_vm_strategy, share_group, system_job_order):
+        url = '/admin/workflow-configurations/'
+        data = {
+            'name': name,
+            'workflow': workflow,
+            'default_vm_strategy': default_vm_strategy,
+            'share_group': share_group,
+            'system_job_order': system_job_order
+        }
+        return self._post_request(url, data)
 
     def workflow_configurations_create_job(self, workflow_configuration_id, job_name, fund_code, stage_group,
                                            user_job_order, job_vm_strategy=None):
@@ -166,10 +190,18 @@ class BespinApi(object):
             url += "?name={}".format(name)
         return self._get_request(url)
 
+    def get_share_group(self, share_group_id):
+        url = '/share-groups/{}/'.format(share_group_id)
+        return self._get_request(url)
+
     def get_vm_strategies(self, name=None):
         url = '/vm-strategies/'
         if name:
             url += "?name={}".format(name)
+        return self._get_request(url)
+
+    def get_vm_strategy(self, vm_strategy_id):
+        url = '/vm-strategies/{}/'.format(vm_strategy_id)
         return self._get_request(url)
 
 

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -124,6 +124,12 @@ class BespinApi(object):
         }
         return self._post_request('/dds-job-input-files/', data)
 
+    def init_job_file(self, tag):
+        return self._post_request('/jobs/init-job-file/', {'workflow_tag': tag})
+
+    def create_job(self, job_file_payload):
+        return self._post_request('/jobs/create-job/', job_file_payload)
+
     def authorize_job(self, job_id, token):
         return self._post_request('/jobs/{}/authorize/'.format(job_id), {'token': token})
 

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -109,6 +109,9 @@ class BespinApi(object):
                 url += "tag={}".format(tag)
         return self._get_request(url)
 
+    def workflow_configurations_get(self, workflow_configuration_id):
+        return self._get_request('/workflow-configurations/{}/'.format(workflow_configuration_id))
+
     def workflow_configurations_post(self, name, workflow, default_vm_strategy, share_group, system_job_order):
         url = '/admin/workflow-configurations/'
         data = {

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -125,10 +125,10 @@ class BespinApi(object):
         return self._post_request('/dds-job-input-files/', data)
 
     def init_job_file(self, tag):
-        return self._post_request('/jobs/init-job-file/', {'workflow_tag': tag})
+        return self._post_request('/job-templates/init-job-file/', {'workflow_tag': tag})
 
     def create_job(self, job_file_payload):
-        return self._post_request('/jobs/create-job/', job_file_payload)
+        return self._post_request('/job-templates/create-job/', job_file_payload)
 
     def authorize_job(self, job_id, token):
         return self._post_request('/jobs/{}/authorize/'.format(job_id), {'token': token})

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -144,17 +144,6 @@ class BespinApi(object):
         }
         return self._post_request(url, data)
 
-    def workflow_configurations_create_job(self, workflow_configuration_id, job_name, fund_code, stage_group,
-                                           user_job_order, job_vm_strategy=None):
-        data = {
-            'job_name': job_name,
-            'fund_code': fund_code,
-            'stage_group': stage_group,
-            'user_job_order': user_job_order,
-            'job_vm_strategy': job_vm_strategy
-        }
-        return self._post_request('/workflow-configurations/{}/create-job/'.format(workflow_configuration_id), data)
-
     def stage_group_post(self):
         return self._post_request('/job-file-stage-groups/', {})
 

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -112,13 +112,12 @@ class BespinApi(object):
     def workflow_configurations_get(self, workflow_configuration_id):
         return self._get_request('/workflow-configurations/{}/'.format(workflow_configuration_id))
 
-    def workflow_configurations_post(self, name, workflow, default_vm_strategy, share_group, system_job_order):
+    def workflow_configurations_post(self, name, workflow, default_vm_strategy, system_job_order):
         url = '/admin/workflow-configurations/'
         data = {
             'name': name,
             'workflow': workflow,
             'default_vm_strategy': default_vm_strategy,
-            'share_group': share_group,
             'system_job_order': system_job_order
         }
         return self._post_request(url, data)
@@ -151,10 +150,10 @@ class BespinApi(object):
         }
         return self._post_request('/dds-job-input-files/', data)
 
-    def init_job_file(self, tag):
-        return self._post_request('/job-templates/init-job-file/', {'workflow_tag': tag})
+    def job_templates_init(self, tag):
+        return self._post_request('/job-templates/init/', {'tag': tag})
 
-    def create_job(self, job_file_payload):
+    def job_templates_create_job(self, job_file_payload):
         return self._post_request('/job-templates/create-job/', job_file_payload)
 
     def authorize_job(self, job_id, token):
@@ -187,23 +186,23 @@ class BespinApi(object):
     def dds_user_credentials_list(self):
         return self._get_request('/dds-user-credentials/')
 
-    def get_share_groups(self, name=None):
+    def share_groups_list(self, name=None):
         url = '/share-groups/'
         if name:
             url += "?name={}".format(name)
         return self._get_request(url)
 
-    def get_share_group(self, share_group_id):
+    def share_group_get(self, share_group_id):
         url = '/share-groups/{}/'.format(share_group_id)
         return self._get_request(url)
 
-    def get_vm_strategies(self, name=None):
+    def vm_strategies_list(self, name=None):
         url = '/vm-strategies/'
         if name:
             url += "?name={}".format(name)
         return self._get_request(url)
 
-    def get_vm_strategy(self, vm_strategy_id):
+    def vm_strategy_get(self, vm_strategy_id):
         url = '/vm-strategies/{}/'.format(vm_strategy_id)
         return self._get_request(url)
 

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -31,7 +31,6 @@ class ArgParser(object):
     def _add_command(self, command_constructor):
             command = command_constructor(self.target_object)
             command_parser = self.subparsers.add_parser(command.name,
-                                                        aliases=[command.alias],
                                                         description=command.description)
             command_subparsers = command_parser.add_subparsers()
             command.add_actions(command_subparsers)
@@ -50,7 +49,6 @@ class ArgParser(object):
 
 class WorkflowCommand(object):
     name = "workflow"
-    alias = "wf"
     description = "workflow commands"
 
     def __init__(self, target):
@@ -85,7 +83,6 @@ class WorkflowCommand(object):
 
 class WorkflowVersionCommand(object):
     name = "workflow-version"
-    alias = "wfv"
     description = "workflow version commands"
 
     def __init__(self, target):
@@ -120,7 +117,6 @@ class WorkflowVersionCommand(object):
 
 class WorkflowConfigCommand(object):
     name = "workflow-config"
-    alias = "wfc"
     description = "workflow configuration commands"
 
     def __init__(self, target):
@@ -173,7 +169,6 @@ class WorkflowConfigCommand(object):
 
 class ShareGroupCommand(object):
     name = "share-group"
-    alias = "sg"
     description = "share group commands"
 
     def __init__(self, target):
@@ -189,7 +184,6 @@ class ShareGroupCommand(object):
 
 class VMConfigCommand(object):
     name = "vm-config"
-    alias = "vmc"
     description = "VM configuration commands"
 
     def __init__(self, target):
@@ -205,7 +199,6 @@ class VMConfigCommand(object):
 
 class JobTemplateCommand(object):
     name = "job-template"
-    alias = "jt"
     description = "job template commands"
 
     def __init__(self, target):
@@ -225,7 +218,6 @@ class JobTemplateCommand(object):
 
 class JobCommand(object):
     name = "job"
-    alias = "j"
     description = "job commands"
 
     def __init__(self, target):

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -46,10 +46,41 @@ class ArgParser(object):
                                  help='show all workflow versions instead of just the most recent.')
         list_parser.set_defaults(func=self._run_list_workflows)
 
-        joborder_parser = workflows_subparser.add_parser('joborder', description='show workflow job order')
+        self._create_workflow_configurations_parser(workflows_subparser)
+        self._create_workflow_versions_parser(workflows_subparser)
+
+    def _create_workflow_configurations_parser(self, subparsers):
+        configurations_parser = subparsers.add_parser('configurations', description='workflow configuration commands')
+        configurations_subparser = configurations_parser.add_subparsers()
+
+        list_parser = configurations_subparser.add_parser('list', description='list workflow configurations')
+        list_parser.set_defaults(func=self._run_list_workflow_configurations)
+
+        joborder_parser = configurations_subparser.add_parser('joborder', description='show workflow configuration job order')
         joborder_parser.add_argument('--tag', type=str, dest='tag', required=True)
         joborder_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
         joborder_parser.set_defaults(func=self._run_show_workflow_job_order)
+
+        create_parser = configurations_subparser.add_parser('create', description='create new workflow configuration')
+        create_parser.add_argument('--name', type=str, dest='name', required=True)
+        create_parser.add_argument('--workflow', type=int, dest='workflow', required=True)
+        create_parser.add_argument('--default-vm-strategy', type=int, dest='default_vm_strategy', required=True)
+        create_parser.add_argument('--share-group', type=int, dest='share_group', required=True)
+        create_parser.add_argument('joborder', type=argparse.FileType('r'), help='job order file')
+        create_parser.set_defaults(func=self._run_create_workflow_configuration)
+
+    def _create_workflow_versions_parser(self, subparsers):
+        versions_parser = subparsers.add_parser('versions', description='workflow versions commands')
+        versions_subparser = versions_parser.add_subparsers()
+        list_parser = versions_subparser.add_parser('list', description='list workflow versions')
+        list_parser.set_defaults(func=self._run_list_workflow_versions)
+
+        create_parser = versions_subparser.add_parser('create', description='create new workflow version')
+        create_parser.add_argument('--workflow', type=int, required=True)
+        create_parser.add_argument('--version', type=int, dest='version_num', required=True)
+        create_parser.add_argument('--description', type=str, required=True)
+        create_parser.add_argument('--url', type=str, required=True, help='URL to packed cwl workflow')
+        create_parser.set_defaults(func=self._run_create_workflow_version)
 
     def _create_job_parser(self, subparsers):
         jobs_parser = subparsers.add_parser('jobs')
@@ -114,11 +145,24 @@ class ArgParser(object):
     def _run_show_workflow_job_order(self, args):
         self.target_object.workflow_configuration_job_order_show(args.tag, args.outfile)
 
+    def _run_list_workflow_configurations(self, args):
+        self.target_object.workflow_configurations_list()
+
     def _run_init_job(self, args):
         self.target_object.init_job(args.tag, args.outfile)
 
     def _run_create_job(self, args):
         self.target_object.create_job(args.infile, args.dry_run, args.share_group, args.vm_strategy)
+
+    def _run_create_workflow_configuration(self, args):
+        self.target_object.create_workflow_configuration(args.name, args.workflow, args.default_vm_strategy,
+                                                         args.share_group, args.joborder)
+
+    def _run_list_workflow_versions(self, args):
+        self.target_object.list_workflow_versions()
+
+    def _run_create_workflow_version(self, args):
+        self.target_object.create_workflow_version(args.workflow, args.version_num, args.description, args.url)
 
     def _run_start_job(self, args):
         self.target_object.start_job(args.job_id, args.token)

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -33,6 +33,8 @@ class ArgParser(object):
         subparsers = argument_parser.add_subparsers()
         self._create_workflows_parser(subparsers)
         self._create_job_parser(subparsers)
+        self._create_share_groups_parser(subparsers)
+        self._create_vm_strategies_parser(subparsers)
         return argument_parser
 
     def _create_workflows_parser(self, subparsers):
@@ -63,6 +65,10 @@ class ArgParser(object):
 
         submit_jobs_parser = jobs_subparser.add_parser('create',
                                                        description="create job using 'infile' from init command")
+        submit_jobs_parser.add_argument('--share-group', type=str, required=True,
+                                        help="id of the share group use for this job")
+        submit_jobs_parser.add_argument('--vm-strategy', type=str,
+                                        help="id of the vm strategy use for this job")
         submit_jobs_parser.add_argument('--dry-run', action='store_true',
                                  help='Do not create a job, instead check the inputs for validity.')
         submit_jobs_parser.set_defaults(func=self._run_create_job)
@@ -85,6 +91,20 @@ class ArgParser(object):
         delete_jobs_parser.set_defaults(func=self._run_delete_job)
         delete_jobs_parser.add_argument('job_id', type=int)
 
+    def _create_share_groups_parser(self, subparsers):
+        share_groups_parser = subparsers.add_parser('sharegroups', description='sharegroups commands')
+        share_groups_subparser = share_groups_parser.add_subparsers()
+
+        list_parser = share_groups_subparser.add_parser('list', description='list share groups')
+        list_parser.set_defaults(func=self._run_list_share_groups)
+
+    def _create_vm_strategies_parser(self, subparsers):
+        share_groups_parser = subparsers.add_parser('vmstrategies', description='VM Stratgies commands')
+        share_groups_subparser = share_groups_parser.add_subparsers()
+
+        list_parser = share_groups_subparser.add_parser('list', description='list vm strategies')
+        list_parser.set_defaults(func=self._run_list_vm_strategies)
+
     def _run_list_jobs(self, _):
         self.target_object.jobs_list()
 
@@ -98,7 +118,7 @@ class ArgParser(object):
         self.target_object.init_job(args.tag, args.outfile)
 
     def _run_create_job(self, args):
-        self.target_object.create_job(args.infile, args.dry_run)
+        self.target_object.create_job(args.infile, args.dry_run, args.share_group, args.vm_strategy)
 
     def _run_start_job(self, args):
         self.target_object.start_job(args.job_id, args.token)
@@ -111,6 +131,12 @@ class ArgParser(object):
 
     def _run_delete_job(self, args):
         self.target_object.delete_job(args.job_id)
+
+    def _run_list_share_groups(self, args):
+        self.target_object.list_share_groups()
+
+    def _run_list_vm_strategies(self, args):
+        self.target_object.list_vm_strategies()
 
     @staticmethod
     def read_argument_file_contents(infile):

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -97,8 +97,6 @@ class ArgParser(object):
 
         submit_jobs_parser = jobs_subparser.add_parser('create',
                                                        description="create job using 'infile' from init command")
-        submit_jobs_parser.add_argument('--share-group', type=str, required=True,
-                                        help="id of the share group use for this job")
         submit_jobs_parser.add_argument('--vm-strategy', type=str,
                                         help="id of the vm strategy use for this job")
         submit_jobs_parser.add_argument('--dry-run', action='store_true',
@@ -153,7 +151,7 @@ class ArgParser(object):
         self.target_object.init_job(args.tag, args.outfile)
 
     def _run_create_job(self, args):
-        self.target_object.create_job(args.infile, args.dry_run, args.share_group, args.vm_strategy)
+        self.target_object.create_job(args.infile, args.dry_run, args.vm_strategy)
 
     def _run_create_workflow_configuration(self, args):
         self.target_object.create_workflow_configuration(args.name, args.workflow, args.default_vm_strategy,

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -46,10 +46,10 @@ class ArgParser(object):
                                  help='show all workflow versions instead of just the most recent.')
         list_parser.set_defaults(func=self._run_list_workflows)
 
-        show_parser = workflows_subparser.add_parser('configuration', description='show workflow configuration')
-        show_parser.add_argument('--tag', type=str, dest='tag', required=True)
-        show_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
-        show_parser.set_defaults(func=self._run_show_workflow_configuration)
+        joborder_parser = workflows_subparser.add_parser('joborder', description='show workflow job order')
+        joborder_parser.add_argument('--tag', type=str, dest='tag', required=True)
+        joborder_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
+        joborder_parser.set_defaults(func=self._run_show_workflow_job_order)
 
     def _create_job_parser(self, subparsers):
         jobs_parser = subparsers.add_parser('jobs')
@@ -111,8 +111,8 @@ class ArgParser(object):
     def _run_list_workflows(self, args):
         self.target_object.workflows_list(all_versions=args.all)
 
-    def _run_show_workflow_configuration(self, args):
-        self.target_object.workflow_configuration_show(args.tag, args.outfile)
+    def _run_show_workflow_job_order(self, args):
+        self.target_object.workflow_configuration_job_order_show(args.tag, args.outfile)
 
     def _run_init_job(self, args):
         self.target_object.init_job(args.tag, args.outfile)

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -91,9 +91,9 @@ class ArgParser(object):
         list_jobs_parser.set_defaults(func=self._run_list_jobs)
 
         init_jobs_parser = jobs_subparser.add_parser('init', description='init job file')
-        init_jobs_parser.set_defaults(func=self._run_init_job)
         init_jobs_parser.add_argument(type=str, dest='tag')
         init_jobs_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
+        init_jobs_parser.set_defaults(func=self._run_job_template_init)
 
         submit_jobs_parser = jobs_subparser.add_parser('create',
                                                        description="create job using 'infile' from init command")
@@ -147,8 +147,8 @@ class ArgParser(object):
     def _run_list_workflow_configurations(self, args):
         self.target_object.workflow_configurations_list()
 
-    def _run_init_job(self, args):
-        self.target_object.init_job(args.tag, args.outfile)
+    def _run_job_template_init(self, args):
+        self.target_object.job_template_init(args.tag, args.outfile)
 
     def _run_create_job(self, args):
         self.target_object.create_job(args.infile, args.dry_run, args.vm_strategy)

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -64,20 +64,23 @@ class WorkflowCommand(object):
         exclusive_flags.add_argument('--short', action='store_true',
                                   help='show short list of only workflows excluding version/configuration data.')
         list_parser.add_argument('tag', nargs='?', metavar='WORKFLOW_TAG', help='Workflow tag to filter by')
-        list_parser.set_defaults(func=self._run_workflows_list)
+        list_parser.set_defaults(func=self._list)
 
         create_parser = subparsers.add_parser('create', description='create a workflow')
         create_parser.add_argument('--name', required=True,
                                    help='Name to describe the workflow.')
         create_parser.add_argument('--tag', required=True,
                                    help='Unique tag of the workflow.')
-        create_parser.set_defaults(func=self._run_workflow_create)
+        create_parser.set_defaults(func=self._create)
 
-    def _run_workflows_list(self, args):
-        self.target.workflows_list(args.all, args.short, args.tag)
+    def _list(self, args):
+        self.target.workflows_list(all_versions=args.all,
+                                   short_format=args.short,
+                                   tag=args.tag)
 
-    def _run_workflow_create(self, args):
-        self.target.workflow_create(args.name, args.tag)
+    def _create(self, args):
+        self.target.workflow_create(name=args.name,
+                                    tag=args.tag)
 
 
 class WorkflowVersionCommand(object):
@@ -92,7 +95,7 @@ class WorkflowVersionCommand(object):
         list_parser = subparsers.add_parser('list', description='list workflow versions')
         list_parser.add_argument('--workflow', metavar='WORKFLOW_TAG',
                                  help='Filter list based on a workflow tag.')
-        list_parser.set_defaults(func=self._run_list_workflow_versions_list)
+        list_parser.set_defaults(func=self._list)
 
         create_parser = subparsers.add_parser('create', description='create new workflow version')
         create_parser.add_argument('--workflow', metavar='WORKFLOW_TAG', required=True,
@@ -103,13 +106,16 @@ class WorkflowVersionCommand(object):
                                    help='Workflow version description')
         create_parser.add_argument('--version', required=True,
                                    help='Version number or "auto" to automatically determine next version.')
-        create_parser.set_defaults(func=self._run_workflow_version_create)
+        create_parser.set_defaults(func=self._create)
 
-    def _run_list_workflow_versions_list(self, args):
-        self.target.workflow_versions_list(args.workflow)
+    def _list(self, args):
+        self.target.workflow_versions_list(workflow_tag=args.workflow)
 
-    def _run_workflow_version_create(self, args):
-        self.target.workflow_version_create(args.workflow, args.url, args.description, args.version)
+    def _create(self, args):
+        self.target.workflow_version_create(workflow_tag=args.workflow,
+                                            url=args.url,
+                                            description=args.description,
+                                            version=args.version)
 
 
 class WorkflowConfigCommand(object):
@@ -124,17 +130,17 @@ class WorkflowConfigCommand(object):
         list_parser = subparsers.add_parser('list', description='list workflow configurations')
         list_parser.add_argument('--workflow', metavar='TAG',
                                  help='Filter list based on a workflow tag.')
-        list_parser.set_defaults(func=self._run_list_workflow_configs)
+        list_parser.set_defaults(func=self._list)
 
         show_job_order_parser = subparsers.add_parser('show-job-order', description='Prints out job order associated '
                                                                                     'with this configuration')
-        show_job_order_parser.add_argument('--workflow', metavar='WORKFLOW_TAG',
+        show_job_order_parser.add_argument('--workflow', metavar='WORKFLOW_TAG', required=True,
                                            help='Specifies workflow that contains the configuration to be printed.')
-        show_job_order_parser.add_argument('--tag',
+        show_job_order_parser.add_argument('--tag', required=True,
                                            help='Specifies which configuration within a workflow to use.')
         show_job_order_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout,
                                            help='File to write job order into. Prints to stdout if not specified.')
-        show_job_order_parser.set_defaults(func=self._run_show_job_order_workflow_config)
+        show_job_order_parser.set_defaults(func=self._show_job_order)
 
         create_parser = subparsers.add_parser('create', description='create new workflow configuration')
         create_parser.add_argument('--workflow', metavar='WORKFLOW_TAG', required=True,
@@ -146,17 +152,23 @@ class WorkflowConfigCommand(object):
         create_parser.add_argument('--tag', required=True,
                                    help='Tag to assign to this worflow configuration')
         create_parser.add_argument('job_order', type=argparse.FileType('r'), help='job order file')
-        create_parser.set_defaults(func=self._run_workflow_config_create)
+        create_parser.set_defaults(func=self._create)
 
-    def _run_list_workflow_configs(self, args):
-        self.target.workflow_configs_list(args.workflow)
+    def _list(self, args):
+        self.target.workflow_configs_list(workflow_tag=args.workflow)
 
-    def _run_show_job_order_workflow_config(self, args):
-        self.target.workflow_config_show_job_order(args.tag, args.workflow, args.outfile)
+    def _show_job_order(self, args):
+        self.target.workflow_config_show_job_order(tag=args.tag,
+                                                   workflow_tag=args.workflow,
+                                                   outfile=args.outfile)
 
-    def _run_workflow_config_create(self, args):
-        self.target.workflow_config_create(args.workflow, args.default_vm_config, args.share_group, args.tag,
-                                           args.job_order)
+    def _create(self, args):
+        self.target.workflow_config_create(
+            workflow_tag=args.workflow,
+            default_vm_strategy_name=args.default_vm_config,
+            share_group_name=args.share_group,
+            tag=args.tag,
+            joborder_infile=args.job_order)
 
 
 class ShareGroupCommand(object):
@@ -169,10 +181,10 @@ class ShareGroupCommand(object):
 
     def add_actions(self, subparsers):
         list_parser = subparsers.add_parser('list', description='list share groups')
-        list_parser.set_defaults(func=self._run_list_share_groups)
+        list_parser.set_defaults(func=self._list)
 
-    def _run_list_share_groups(self, args):
-        self.target.list_share_groups()
+    def _list(self, args):
+        self.target.share_groups_list()
 
 
 class VMConfigCommand(object):
@@ -185,10 +197,10 @@ class VMConfigCommand(object):
 
     def add_actions(self, subparsers):
         list_parser = subparsers.add_parser('list', description='list VM configurations')
-        list_parser.set_defaults(func=self._run_list_vm_configs)
+        list_parser.set_defaults(func=self._list)
 
-    def _run_list_vm_configs(self, args):
-        self.target.list_vm_configs()
+    def _list(self, args):
+        self.target.vm_configs_list()
 
 
 class JobTemplateCommand(object):
@@ -205,10 +217,10 @@ class JobTemplateCommand(object):
                                    help='Tag that specifies workflow version and config to create job template for')
         create_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout,
                                    help='File to write job template into. Prints to stdout if not specified.')
-        create_parser.set_defaults(func=self._run_create_job_template)
+        create_parser.set_defaults(func=self._create)
 
-    def _run_create_job_template(self, args):
-        self.target.job_template_create(args.tag, args.outfile)
+    def _create(self, args):
+        self.target.job_template_create(tag=args.tag, outfile=args.outfile)
 
 
 class JobCommand(object):
@@ -222,57 +234,57 @@ class JobCommand(object):
     def add_actions(self, subparsers):
         create_parser = subparsers.add_parser('create', description='create a job based on a job template file')
         create_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
-        create_parser.set_defaults(func=self._create_job)
+        create_parser.set_defaults(func=self._create)
 
         run_parser = subparsers.add_parser('run', description='create and start a job based on a job template file')
         run_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
         run_parser.add_argument('--token', type=str, help='Token used to authorize job (if necessary)')
-        run_parser.set_defaults(func=self._run_job)
+        run_parser.set_defaults(func=self._run)
 
         validate_parser = subparsers.add_parser('validate', description='validate a job template file')
         validate_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
-        validate_parser.set_defaults(func=self._validate_job)
+        validate_parser.set_defaults(func=self._validate)
 
         list_parser = subparsers.add_parser('list', description='list jobs')
-        list_parser.set_defaults(func=self._list_jobs)
+        list_parser.set_defaults(func=self._list)
 
         start_parser = subparsers.add_parser('start', description='start job')
         start_parser.add_argument('job_id', type=int)
         start_parser.add_argument('--token', type=str, help='Token used to authorize job (if necessary)')
-        start_parser.set_defaults(func=self._start_job)
+        start_parser.set_defaults(func=self._start)
 
         cancel_parser = subparsers.add_parser('cancel', description='cancel job')
         cancel_parser.add_argument('job_id', type=int)
-        cancel_parser.set_defaults(func=self._cancel_job)
+        cancel_parser.set_defaults(func=self._cancel)
 
         restart_parser = subparsers.add_parser('restart', description='restart job')
         restart_parser.add_argument('job_id', type=int)
-        restart_parser.set_defaults(func=self._restart_job)
+        restart_parser.set_defaults(func=self._restart)
 
         delete_parser = subparsers.add_parser('delete', description='delete job')
         delete_parser.add_argument('job_id', type=int)
-        delete_parser.set_defaults(func=self._delete_job)
+        delete_parser.set_defaults(func=self._delete)
 
-    def _create_job(self, args):
-        self.target.job_create(args.job_template)
+    def _create(self, args):
+        self.target.job_create(job_template_infile=args.job_template)
 
-    def _run_job(self, args):
-        self.target.job_run(args.job_template, args.token)
+    def _run(self, args):
+        self.target.job_run(job_template_infile=args.job_template, token=args.token)
 
-    def _validate_job(self, args):
-        self.target.job_validate(args.job_template)
+    def _validate(self, args):
+        self.target.job_validate(job_template_infile=args.job_template)
 
-    def _list_jobs(self, args):
+    def _list(self, args):
         self.target.jobs_list()
 
-    def _start_job(self, args):
-        self.target.start_job(args.job_id, args.token)
+    def _start(self, args):
+        self.target.start_job(job_id=args.job_id, token=args.token)
 
-    def _cancel_job(self, args):
-        self.target.cancel_job(args.job_id)
+    def _cancel(self, args):
+        self.target.cancel_job(job_id=args.job_id)
 
-    def _restart_job(self, args):
-        self.target.restart_job(args.job_id)
+    def _restart(self, args):
+        self.target.restart_job(job_id=args.job_id)
 
-    def _delete_job(self, args):
-        self.target.delete_job(args.job_id)
+    def _delete(self, args):
+        self.target.delete_job(job_id=args.job_id)

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -10,12 +10,31 @@ class ArgParser(object):
         """
         Create argument parser with the specified version string that will call the appropriate methods
         in target_object when those commands are selected.
-        :param version_str: str: version of datadelivery
+        :param version_str: str: version of bespin-cli
         :param target_object: object: object with methods named the same as the commands
         """
-        self.version_str = version_str
         self.target_object = target_object
-        self.argument_parser = self._create_argument_parser()
+        description = DESCRIPTION_STR.format(version_str)
+        self.argument_parser = argparse.ArgumentParser(description=description)
+        self.subparsers = self.argument_parser.add_subparsers()
+        self._add_commands_to_parser()
+
+    def _add_commands_to_parser(self):
+        self._add_command(WorkflowCommand)
+        self._add_command(WorkflowVersionCommand)
+        self._add_command(WorkflowConfigCommand)
+        self._add_command(ShareGroupCommand)
+        self._add_command(VMConfigCommand)
+        self._add_command(JobTemplateCommand)
+        self._add_command(JobCommand)
+
+    def _add_command(self, command_constructor):
+            command = command_constructor(self.target_object)
+            command_parser = self.subparsers.add_parser(command.name,
+                                                        aliases=[command.alias],
+                                                        description=command.description)
+            command_subparsers = command_parser.add_subparsers()
+            command.add_actions(command_subparsers)
 
     def parse_and_run_commands(self, args=None):
         """
@@ -28,169 +47,232 @@ class ArgParser(object):
         else:
             self.argument_parser.print_help()
 
-    def _create_argument_parser(self):
-        argument_parser = argparse.ArgumentParser(description=DESCRIPTION_STR.format(self.version_str))
-        subparsers = argument_parser.add_subparsers()
-        self._create_workflows_parser(subparsers)
-        self._create_job_parser(subparsers)
-        self._create_share_groups_parser(subparsers)
-        self._create_vm_strategies_parser(subparsers)
-        return argument_parser
 
-    def _create_workflows_parser(self, subparsers):
-        workflows_parser = subparsers.add_parser('workflows', description='workflows commands')
-        workflows_subparser = workflows_parser.add_subparsers()
+class WorkflowCommand(object):
+    name = "workflow"
+    alias = "wf"
+    description = "workflow commands"
 
-        list_parser = workflows_subparser.add_parser('list', description='list workflows')
-        list_parser.add_argument('-a', '--all', action='store_true',
-                                 help='show all workflow versions instead of just the most recent.')
-        list_parser.set_defaults(func=self._run_list_workflows)
+    def __init__(self, target):
+        self.target = target
 
-        self._create_workflow_configurations_parser(workflows_subparser)
-        self._create_workflow_versions_parser(workflows_subparser)
+    def add_actions(self, subparsers):
+        list_parser = subparsers.add_parser('list', description='list workflows')
+        exclusive_flags = list_parser.add_mutually_exclusive_group()
+        exclusive_flags.add_argument('--all', action='store_true',
+                                  help='show all workflow versions instead of just the most recent.')
+        exclusive_flags.add_argument('--short', action='store_true',
+                                  help='show short list of only workflows excluding version/configuration data.')
+        list_parser.add_argument('tag', nargs='?', metavar='WORKFLOW_TAG', help='Workflow tag to filter by')
+        list_parser.set_defaults(func=self._run_workflows_list)
 
-    def _create_workflow_configurations_parser(self, subparsers):
-        configurations_parser = subparsers.add_parser('configurations', description='workflow configuration commands')
-        configurations_subparser = configurations_parser.add_subparsers()
+        create_parser = subparsers.add_parser('create', description='create a workflow')
+        create_parser.add_argument('--name', required=True,
+                                   help='Name to describe the workflow.')
+        create_parser.add_argument('--tag', required=True,
+                                   help='Unique tag of the workflow.')
+        create_parser.set_defaults(func=self._run_workflow_create)
 
-        list_parser = configurations_subparser.add_parser('list', description='list workflow configurations')
-        list_parser.set_defaults(func=self._run_list_workflow_configurations)
+    def _run_workflows_list(self, args):
+        self.target.workflows_list(args.all, args.short, args.tag)
 
-        joborder_parser = configurations_subparser.add_parser('job-order',
-                                                              description='show workflow configuration job order')
-        joborder_parser.add_argument('workflow_configuration_id', type=int)
-        joborder_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
-        joborder_parser.set_defaults(func=self._run_show_workflow_job_order)
+    def _run_workflow_create(self, args):
+        self.target.workflow_create(args.name, args.tag)
 
-        create_parser = configurations_subparser.add_parser('create', description='create new workflow configuration')
-        create_parser.add_argument('--name', type=str, dest='name', required=True)
-        create_parser.add_argument('--workflow', type=int, dest='workflow', required=True)
-        create_parser.add_argument('--default-vm-strategy', type=int, dest='default_vm_strategy', required=True)
-        create_parser.add_argument('--share-group', type=int, dest='share_group', required=True)
-        create_parser.add_argument('joborder', type=argparse.FileType('r'), help='job order file')
-        create_parser.set_defaults(func=self._run_create_workflow_configuration)
 
-    def _create_workflow_versions_parser(self, subparsers):
-        versions_parser = subparsers.add_parser('versions', description='workflow versions commands')
-        versions_subparser = versions_parser.add_subparsers()
-        list_parser = versions_subparser.add_parser('list', description='list workflow versions')
-        list_parser.set_defaults(func=self._run_list_workflow_versions)
+class WorkflowVersionCommand(object):
+    name = "workflow-version"
+    alias = "wfv"
+    description = "workflow version commands"
 
-        create_parser = versions_subparser.add_parser('create', description='create new workflow version')
-        create_parser.add_argument('--workflow', type=int, required=True)
-        create_parser.add_argument('--version', type=int, dest='version_num', required=True)
-        create_parser.add_argument('--description', type=str, required=True)
-        create_parser.add_argument('--url', type=str, required=True, help='URL to packed cwl workflow')
-        create_parser.set_defaults(func=self._run_create_workflow_version)
+    def __init__(self, target):
+        self.target = target
 
-    def _create_job_parser(self, subparsers):
-        jobs_parser = subparsers.add_parser('jobs')
-        jobs_subparser = jobs_parser.add_subparsers()
+    def add_actions(self, subparsers):
+        list_parser = subparsers.add_parser('list', description='list workflow versions')
+        list_parser.add_argument('--workflow', metavar='WORKFLOW_TAG',
+                                 help='Filter list based on a workflow tag.')
+        list_parser.set_defaults(func=self._run_list_workflow_versions_list)
 
-        list_jobs_parser = jobs_subparser.add_parser('list', description='list jobs')
-        list_jobs_parser.set_defaults(func=self._run_list_jobs)
+        create_parser = subparsers.add_parser('create', description='create new workflow version')
+        create_parser.add_argument('--workflow', metavar='WORKFLOW_TAG', required=True,
+                                   help='Tag specifying workflow to assign this workflow version to')
+        create_parser.add_argument('--url', required=True,
+                                   help='URL that specifies the packed CWL workflow')
+        create_parser.add_argument('--description', required=True,
+                                   help='Workflow version description')
+        create_parser.add_argument('--version', required=True,
+                                   help='Version number or "auto" to automatically determine next version.')
+        create_parser.set_defaults(func=self._run_workflow_version_create)
 
-        init_jobs_parser = jobs_subparser.add_parser('init', description='init job file')
-        init_jobs_parser.add_argument(type=str, dest='tag')
-        init_jobs_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
-        init_jobs_parser.set_defaults(func=self._run_job_template_init)
+    def _run_list_workflow_versions_list(self, args):
+        self.target.workflow_versions_list(args.workflow)
 
-        submit_jobs_parser = jobs_subparser.add_parser('create',
-                                                       description="create job using 'infile' from init command")
-        submit_jobs_parser.add_argument('--vm-strategy', type=str,
-                                        help="id of the vm strategy use for this job")
-        submit_jobs_parser.add_argument('--dry-run', action='store_true',
-                                 help='Do not create a job, instead check the inputs for validity.')
-        submit_jobs_parser.set_defaults(func=self._run_create_job)
-        submit_jobs_parser.add_argument('infile', type=argparse.FileType('r'), help='file created by init command')
+    def _run_workflow_version_create(self, args):
+        self.target.workflow_version_create(args.workflow, args.url, args.description, args.version)
 
-        start_jobs_parser = jobs_subparser.add_parser('start', description='start job')
-        start_jobs_parser.set_defaults(func=self._run_start_job)
-        start_jobs_parser.add_argument('job_id', type=int)
-        start_jobs_parser.add_argument('--token', type=str)
 
-        cancel_jobs_parser = jobs_subparser.add_parser('cancel', description='cancel job')
-        cancel_jobs_parser.set_defaults(func=self._run_cancel_job)
-        cancel_jobs_parser.add_argument('job_id', type=int)
+class WorkflowConfigCommand(object):
+    name = "workflow-config"
+    alias = "wfc"
+    description = "workflow configuration commands"
 
-        restart_jobs_parser = jobs_subparser.add_parser('restart', description='restart job')
-        restart_jobs_parser.set_defaults(func=self._run_restart_job)
-        restart_jobs_parser.add_argument('job_id', type=int)
+    def __init__(self, target):
+        self.target = target
 
-        delete_jobs_parser = jobs_subparser.add_parser('delete', description='delete job')
-        delete_jobs_parser.set_defaults(func=self._run_delete_job)
-        delete_jobs_parser.add_argument('job_id', type=int)
+    def add_actions(self, subparsers):
+        list_parser = subparsers.add_parser('list', description='list workflow configurations')
+        list_parser.add_argument('--workflow', metavar='TAG',
+                                 help='Filter list based on a workflow tag.')
+        list_parser.set_defaults(func=self._run_list_workflow_configs)
 
-    def _create_share_groups_parser(self, subparsers):
-        share_groups_parser = subparsers.add_parser('sharegroups', description='sharegroups commands')
-        share_groups_subparser = share_groups_parser.add_subparsers()
+        show_job_order_parser = subparsers.add_parser('show-job-order', description='Prints out job order associated '
+                                                                                    'with this configuration')
+        show_job_order_parser.add_argument('--workflow', metavar='WORKFLOW_TAG',
+                                           help='Specifies workflow that contains the configuration to be printed.')
+        show_job_order_parser.add_argument('--tag',
+                                           help='Specifies which configuration within a workflow to use.')
+        show_job_order_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout,
+                                           help='File to write job order into. Prints to stdout if not specified.')
+        show_job_order_parser.set_defaults(func=self._run_show_job_order_workflow_config)
 
-        list_parser = share_groups_subparser.add_parser('list', description='list share groups')
+        create_parser = subparsers.add_parser('create', description='create new workflow configuration')
+        create_parser.add_argument('--workflow', metavar='WORKFLOW_TAG', required=True,
+                                   help='Tag specifying workflow to assign this workflow configuration to')
+        create_parser.add_argument('--default-vm-config', required=True, metavar='VM_CONFIG_NAME',
+                                   help='Name of the default VM configuration to use')
+        create_parser.add_argument('--share-group', required=True, metavar='SHARE_GROUP_NAME',
+                                   help='Name of the share group')
+        create_parser.add_argument('--tag', required=True,
+                                   help='Tag to assign to this worflow configuration')
+        create_parser.add_argument('job_order', type=argparse.FileType('r'), help='job order file')
+        create_parser.set_defaults(func=self._run_workflow_config_create)
+
+    def _run_list_workflow_configs(self, args):
+        self.target.workflow_configs_list(args.workflow)
+
+    def _run_show_job_order_workflow_config(self, args):
+        self.target.workflow_config_show_job_order(args.tag, args.workflow, args.outfile)
+
+    def _run_workflow_config_create(self, args):
+        self.target.workflow_config_create(args.workflow, args.default_vm_config, args.share_group, args.tag,
+                                           args.job_order)
+
+
+class ShareGroupCommand(object):
+    name = "share-group"
+    alias = "sg"
+    description = "share group commands"
+
+    def __init__(self, target):
+        self.target = target
+
+    def add_actions(self, subparsers):
+        list_parser = subparsers.add_parser('list', description='list share groups')
         list_parser.set_defaults(func=self._run_list_share_groups)
 
-    def _create_vm_strategies_parser(self, subparsers):
-        share_groups_parser = subparsers.add_parser('vmstrategies', description='VM Stratgies commands')
-        share_groups_subparser = share_groups_parser.add_subparsers()
-
-        list_parser = share_groups_subparser.add_parser('list', description='list vm strategies')
-        list_parser.set_defaults(func=self._run_list_vm_strategies)
-
-    def _run_list_jobs(self, _):
-        self.target_object.jobs_list()
-
-    def _run_list_workflows(self, args):
-        self.target_object.workflows_list(all_versions=args.all)
-
-    def _run_show_workflow_job_order(self, args):
-        self.target_object.workflow_configuration_job_order_show(args.workflow_configuration_id, args.outfile)
-
-    def _run_list_workflow_configurations(self, args):
-        self.target_object.workflow_configurations_list()
-
-    def _run_job_template_init(self, args):
-        self.target_object.job_template_init(args.tag, args.outfile)
-
-    def _run_create_job(self, args):
-        self.target_object.create_job(args.infile, args.dry_run, args.vm_strategy)
-
-    def _run_create_workflow_configuration(self, args):
-        self.target_object.create_workflow_configuration(args.name, args.workflow, args.default_vm_strategy,
-                                                         args.share_group, args.joborder)
-
-    def _run_list_workflow_versions(self, args):
-        self.target_object.list_workflow_versions()
-
-    def _run_create_workflow_version(self, args):
-        self.target_object.create_workflow_version(args.workflow, args.version_num, args.description, args.url)
-
-    def _run_start_job(self, args):
-        self.target_object.start_job(args.job_id, args.token)
-
-    def _run_cancel_job(self, args):
-        self.target_object.cancel_job(args.job_id)
-
-    def _run_restart_job(self, args):
-        self.target_object.restart_job(args.job_id)
-
-    def _run_delete_job(self, args):
-        self.target_object.delete_job(args.job_id)
-
     def _run_list_share_groups(self, args):
-        self.target_object.list_share_groups()
+        self.target.list_share_groups()
 
-    def _run_list_vm_strategies(self, args):
-        self.target_object.list_vm_strategies()
 
-    @staticmethod
-    def read_argument_file_contents(infile):
-        """
-        return the contents of a file or "" if infile is None.
-        If the infile is STDIN displays a message to tell user how to quit entering data.
-        :param infile: file handle to read from
-        :return: str: contents of the file
-        """
-        if infile:
-            if infile == sys.stdin:
-                print("Enter message and press CTRL-d when done:")
-            return infile.read()
-        return ""
+class VMConfigCommand(object):
+    name = "vm-config"
+    alias = "vmc"
+    description = "VM configuration commands"
+
+    def __init__(self, target):
+        self.target = target
+
+    def add_actions(self, subparsers):
+        list_parser = subparsers.add_parser('list', description='list VM configurations')
+        list_parser.set_defaults(func=self._run_list_vm_configs)
+
+    def _run_list_vm_configs(self, args):
+        self.target.list_vm_configs()
+
+
+class JobTemplateCommand(object):
+    name = "job-template"
+    alias = "jt"
+    description = "job template commands"
+
+    def __init__(self, target):
+        self.target = target
+
+    def add_actions(self, subparsers):
+        create_parser = subparsers.add_parser('create', description='create job template for a workflow tag')
+        create_parser.add_argument('tag',
+                                   help='Tag that specifies workflow version and config to create job template for')
+        create_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout,
+                                   help='File to write job template into. Prints to stdout if not specified.')
+        create_parser.set_defaults(func=self._run_create_job_template)
+
+    def _run_create_job_template(self, args):
+        self.target.job_template_create(args.tag, args.outfile)
+
+
+class JobCommand(object):
+    name = "job"
+    alias = "j"
+    description = "job commands"
+
+    def __init__(self, target):
+        self.target = target
+
+    def add_actions(self, subparsers):
+        create_parser = subparsers.add_parser('create', description='create a job based on a job template file')
+        create_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
+        create_parser.set_defaults(func=self._create_job)
+
+        run_parser = subparsers.add_parser('run', description='create and start a job based on a job template file')
+        run_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
+        run_parser.add_argument('--token', type=str, help='Token used to authorize job (if necessary)')
+        run_parser.set_defaults(func=self._run_job)
+
+        validate_parser = subparsers.add_parser('validate', description='validate a job template file')
+        validate_parser.add_argument('job_template', type=argparse.FileType('r'), help='job template file')
+        validate_parser.set_defaults(func=self._validate_job)
+
+        list_parser = subparsers.add_parser('list', description='list jobs')
+        list_parser.set_defaults(func=self._list_jobs)
+
+        start_parser = subparsers.add_parser('start', description='start job')
+        start_parser.add_argument('job_id', type=int)
+        start_parser.add_argument('--token', type=str, help='Token used to authorize job (if necessary)')
+        start_parser.set_defaults(func=self._start_job)
+
+        cancel_parser = subparsers.add_parser('cancel', description='cancel job')
+        cancel_parser.add_argument('job_id', type=int)
+        cancel_parser.set_defaults(func=self._cancel_job)
+
+        restart_parser = subparsers.add_parser('restart', description='restart job')
+        restart_parser.add_argument('job_id', type=int)
+        restart_parser.set_defaults(func=self._restart_job)
+
+        delete_parser = subparsers.add_parser('delete', description='delete job')
+        delete_parser.add_argument('job_id', type=int)
+        delete_parser.set_defaults(func=self._delete_job)
+
+    def _create_job(self, args):
+        self.target.job_create(args.job_template)
+
+    def _run_job(self, args):
+        self.target.job_run(args.job_template, args.token)
+
+    def _validate_job(self, args):
+        self.target.job_validate(args.job_template)
+
+    def _list_jobs(self, args):
+        self.target.jobs_list()
+
+    def _start_job(self, args):
+        self.target.start_job(args.job_id, args.token)
+
+    def _cancel_job(self, args):
+        self.target.cancel_job(args.job_id)
+
+    def _restart_job(self, args):
+        self.target.restart_job(args.job_id)
+
+    def _delete_job(self, args):
+        self.target.delete_job(args.job_id)

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -56,8 +56,9 @@ class ArgParser(object):
         list_parser = configurations_subparser.add_parser('list', description='list workflow configurations')
         list_parser.set_defaults(func=self._run_list_workflow_configurations)
 
-        joborder_parser = configurations_subparser.add_parser('joborder', description='show workflow configuration job order')
-        joborder_parser.add_argument('--tag', type=str, dest='tag', required=True)
+        joborder_parser = configurations_subparser.add_parser('job-order',
+                                                              description='show workflow configuration job order')
+        joborder_parser.add_argument('workflow_configuration_id', type=int)
         joborder_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
         joborder_parser.set_defaults(func=self._run_show_workflow_job_order)
 
@@ -143,7 +144,7 @@ class ArgParser(object):
         self.target_object.workflows_list(all_versions=args.all)
 
     def _run_show_workflow_job_order(self, args):
-        self.target_object.workflow_configuration_job_order_show(args.tag, args.outfile)
+        self.target_object.workflow_configuration_job_order_show(args.workflow_configuration_id, args.outfile)
 
     def _run_list_workflow_configurations(self, args):
         self.target_object.workflow_configurations_list()

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -58,7 +58,7 @@ class ArgParser(object):
 
         init_jobs_parser = jobs_subparser.add_parser('init', description='init job file')
         init_jobs_parser.set_defaults(func=self._run_init_job)
-        init_jobs_parser.add_argument('--tag', type=str, dest='tag', required=True)
+        init_jobs_parser.add_argument(type=str, dest='tag')
         init_jobs_parser.add_argument('--outfile', type=argparse.FileType('w'), dest='outfile', default=sys.stdout)
 
         submit_jobs_parser = jobs_subparser.add_parser('create',

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -6,7 +6,6 @@ from bespin.dukeds import DDSFileUtil
 from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
 from tabulate import tabulate
 import yaml
-import json
 import sys
 from decimal import Decimal, ROUND_HALF_UP
 

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -212,7 +212,7 @@ class WorkflowDetails(object):
                 for version_id in versions:
                     workflow_version = self.api.workflow_version_get(version_id)
                     for workflow_configuration in self.api.workflow_configurations_list(workflow_version=version_id):
-                        tag = '{}/{}/{}'.format(workflow['tag'], workflow_version['tag'], workflow_configuration['tag'])
+                        tag = '{}/{}'.format(workflow_version['tag'], workflow_configuration['tag'])
                         workflow[self.TAG_COLUMN_NAME] = tag
                         data.append(dict(workflow))
         return data

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -288,6 +288,7 @@ class WorkflowConfigurationsList(object):
     WORKFLOW_FIELDNAME = "workflow"
     SHARE_GROUP_FIELDNAME = "share group"
     DEFAULT_VM_STRATEGY_FIELDNAME = "Default VM Strategy"
+
     def __init__(self, api, workflow_tag):
         self.api = api
         self.workflow_tag = workflow_tag

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -72,9 +72,9 @@ class Commands(object):
         workflow_data = WorkflowDetails(api, all_versions)
         print(Table(workflow_data.column_names, workflow_data.get_column_data()))
 
-    def workflow_configuration_job_order_show(self, tag, outfile):
+    def workflow_configuration_job_order_show(self, workflow_configuration_id, outfile):
         api = self._create_api()
-        workflow_configuration = api.workflow_configurations_list(tag=tag)[0]
+        workflow_configuration = api.workflow_configurations_get(workflow_configuration_id)
         outfile.write(yaml.dump(workflow_configuration['system_job_order'], default_flow_style=False))
 
     def jobs_list(self):

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -72,10 +72,10 @@ class Commands(object):
         workflow_data = WorkflowDetails(api, all_versions)
         print(Table(workflow_data.column_names, workflow_data.get_column_data()))
 
-    def workflow_configuration_show(self, tag, outfile):
+    def workflow_configuration_job_order_show(self, tag, outfile):
         api = self._create_api()
         workflow_configuration = api.workflow_configurations_list(tag=tag)[0]
-        outfile.write(yaml.dump(workflow_configuration, default_flow_style=False))
+        outfile.write(yaml.dump(workflow_configuration['system_job_order'], default_flow_style=False))
 
     def jobs_list(self):
         """
@@ -113,8 +113,8 @@ class Commands(object):
             job_file.verify_job(api)
             print("Job file is valid.")
         else:
-            job = job_file.create_job(api)
-            job_id = job['id']
+            result = job_file.create_job(api)
+            job_id = result['job']
             print("Created job {}".format(job_id))
             print("To start this job run `bespin jobs start {}` .".format(job_id))
 

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -52,9 +52,9 @@ class Commands(object):
         api = self._create_api()
         self._print_details_as_table(WorkflowVersionsList(api, workflow_tag))
 
-    def workflow_version_create(self, workflow, url, description, version):
+    def workflow_version_create(self, workflow_tag, url, description, version):
         api = self._create_api()
-        workflow_version = CWLWorkflowVersion(workflow, url, description, version)
+        workflow_version = CWLWorkflowVersion(workflow_tag, url, description, version)
         response = workflow_version.create(api)
         print("Created workflow version {}.".format(response['id']))
 
@@ -84,6 +84,16 @@ class Commands(object):
                                                     joborder)
         print("Created workflow config {}.".format(response['id']))
 
+    def share_groups_list(self):
+        api = self._create_api()
+        item_list = ShareGroupsList(api)
+        print(Table(item_list.column_names, item_list.get_column_data()))
+
+    def vm_configs_list(self):
+        api = self._create_api()
+        item_list = VmStrategiesList(api)
+        print(Table(item_list.column_names, item_list.get_column_data()))
+
     def jobs_list(self):
         """
         Print out a table of current job statuses
@@ -105,28 +115,28 @@ class Commands(object):
             print("Wrote job file {}.".format(outfile.name))
             print("Edit this file filling in TODO fields then run `bespin jobs create {}` .".format(outfile.name))
 
-    def job_create(self, infile):
+    def job_create(self, job_template_infile):
         """
         Create a job based on an input job file (possibly created via init_job_template)
         Prints out job id.
-        :param infile: file: input file to use for creating a job
+        :param job_template_infile: file: input file to use for creating a job
         """
         api = self._create_api()
-        job_template = JobTemplateLoader(infile).create_job_template()
+        job_template = JobTemplateLoader(job_template_infile).create_job_template()
         result = job_template.create_job(api)
         job_id = result['job']
         print("Created job {}".format(job_id))
         print("To start this job run `bespin jobs start {}` .".format(job_id))
 
-    def job_run(self, infile, token=None):
+    def job_run(self, job_template_infile, token=None):
         """
         Creates and starts a job based on an input job file (possibly created via init_job_template)
         Prints out job id.
-        :param infile: file: input file to use for creating a job
+        :param job_template_infile: file: input file to use for creating a job
         :param token: str: token to use to authorize running the job
         """
         api = self._create_api()
-        job_template = JobTemplateLoader(infile).create_job_template()
+        job_template = JobTemplateLoader(job_template_infile).create_job_template()
         result = job_template.create_job(api)
         job_id = result['job']
         print("Created job {}".format(job_id))
@@ -136,13 +146,13 @@ class Commands(object):
         api.start_job(job_id)
         print("Started job {}".format(job_id))
 
-    def job_validate(self, infile):
+    def job_validate(self, job_template_infile):
         """
         Validates a job can be created for the specified job template.
-        :param infile: file: input file to use for creating a job
+        :param job_template_infile: file: input file to use for creating a job
         """
         api = self._create_api()
-        job_template = JobTemplateLoader(infile).create_job_template()
+        job_template = JobTemplateLoader(job_template_infile).create_job_template()
         job_template.verify_job(api)
         print("Job file is valid.")
 
@@ -186,15 +196,6 @@ class Commands(object):
         api.delete_job(job_id)
         print("Deleted job {}".format(job_id))
 
-    def list_share_groups(self):
-        api = self._create_api()
-        item_list = ShareGroupsList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
-
-    def list_vm_configs(self):
-        api = self._create_api()
-        item_list = VmStrategiesList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
 
 
 class Table(object):

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -3,6 +3,7 @@ from bespin.config import ConfigFile
 from bespin.api import BespinApi
 from bespin.workflow import CWLWorkflowVersion
 from bespin.jobtemplate import JobTemplateLoader
+from bespin.exceptions import WorkflowConfigurationNotFoundException
 from tabulate import tabulate
 import yaml
 import sys
@@ -26,19 +27,62 @@ class Commands(object):
         config = ConfigFile().read_or_create_config()
         return BespinApi(config, user_agent_str=self.user_agent_str)
 
-    def workflows_list(self, all_versions):
-        """
-        Print out a table of workflows/questionnaires
-        :param all_versions: bool: when true show all versions otherwise show most recent
-        """
-        api = self._create_api()
-        workflow_data = WorkflowDetails(api, all_versions)
-        print(Table(workflow_data.column_names, workflow_data.get_column_data()))
+    def _print_details_as_table(self, details):
+        print(Table(details.column_names, details.get_column_data()))
 
-    def workflow_configuration_job_order_show(self, workflow_configuration_id, outfile):
+    def workflows_list(self, all_versions, short_format, tag):
+        """
+        Print out a table of workflows and optionally the versions/configurations
+        :param all_versions: bool: when true show all versions otherwise show most recent
+        :param short_format: bool: when true show only workflow info
+        :param tag: str: when true show all versions otherwise show most recent
+        """
         api = self._create_api()
-        workflow_configuration = api.workflow_configurations_get(workflow_configuration_id)
-        outfile.write(yaml.dump(workflow_configuration['system_job_order'], default_flow_style=False))
+        if short_format:
+            self._print_details_as_table(ShortWorkflowDetails(api, tag))
+        else:
+            self._print_details_as_table(FullWorkflowDetails(api, all_versions, tag))
+
+    def workflow_create(self, name, tag):
+        api = self._create_api()
+        response = api.workflow_post(name, tag)
+        print("Created workflow {}.".format(response['id']))
+
+    def workflow_versions_list(self, workflow_tag):
+        api = self._create_api()
+        self._print_details_as_table(WorkflowVersionsList(api, workflow_tag))
+
+    def workflow_version_create(self, workflow, url, description, version):
+        api = self._create_api()
+        workflow_version = CWLWorkflowVersion(workflow, url, description, version)
+        response = workflow_version.create(api)
+        print("Created workflow version {}.".format(response['id']))
+
+    def workflow_configs_list(self, workflow_tag):
+        api = self._create_api()
+        self._print_details_as_table(WorkflowConfigurationsList(api, workflow_tag))
+
+    def workflow_config_show_job_order(self, tag, workflow_tag, outfile):
+        api = self._create_api()
+        configs = api.workflow_configurations_list(tag=tag, workflow_tag=workflow_tag)
+        if not configs:
+            msg = "Workflow configuration not found for tag {} and workflow {}".format(tag, workflow_tag)
+            raise WorkflowConfigurationNotFoundException(msg)
+        config = configs[0]
+        outfile.write(yaml.dump(config['system_job_order'], default_flow_style=False))
+
+    def workflow_config_create(self, workflow_tag, default_vm_strategy_name, share_group_name, tag, joborder_infile):
+        api = self._create_api()
+        joborder = yaml.load(joborder_infile)
+        workflow = api.workflow_get_for_tag(workflow_tag)
+        default_vm_strategy = api.vm_strategy_get_for_name(default_vm_strategy_name)
+        share_group = api.share_group_get_for_name(share_group_name)
+        response = api.workflow_configurations_post(tag,
+                                                    workflow['id'],
+                                                    default_vm_strategy['id'],
+                                                    share_group['id'],
+                                                    joborder)
+        print("Created workflow config {}.".format(response['id']))
 
     def jobs_list(self):
         """
@@ -48,7 +92,7 @@ class Commands(object):
         jobs_list = JobsList(api)
         print(Table(jobs_list.column_names, jobs_list.get_column_data()))
 
-    def job_template_init(self, tag, outfile):
+    def job_template_create(self, tag, outfile):
         """
         Write a sample job file with placeholder values to outfile
         :param tag: str: tag representing which workflow/questionnaire to use
@@ -61,24 +105,46 @@ class Commands(object):
             print("Wrote job file {}.".format(outfile.name))
             print("Edit this file filling in TODO fields then run `bespin jobs create {}` .".format(outfile.name))
 
-    def create_job(self, infile, dry_run, vm_strategy=None):
+    def job_create(self, infile):
         """
         Create a job based on an input job file (possibly created via init_job_template)
         Prints out job id.
         :param infile: file: input file to use for creating a job
-        :param dry_run: boolean: when True do not actually create a job just validate the input
-        :param vm_strategy: int: vm strategy id
         """
         api = self._create_api()
-        job_template = JobTemplateLoader(infile).create_job_template(vm_strategy)
-        if dry_run:
-            job_template.verify_job(api)
-            print("Job file is valid.")
-        else:
-            result = job_template.create_job(api)
-            job_id = result['job']
-            print("Created job {}".format(job_id))
-            print("To start this job run `bespin jobs start {}` .".format(job_id))
+        job_template = JobTemplateLoader(infile).create_job_template()
+        result = job_template.create_job(api)
+        job_id = result['job']
+        print("Created job {}".format(job_id))
+        print("To start this job run `bespin jobs start {}` .".format(job_id))
+
+    def job_run(self, infile, token=None):
+        """
+        Creates and starts a job based on an input job file (possibly created via init_job_template)
+        Prints out job id.
+        :param infile: file: input file to use for creating a job
+        :param token: str: token to use to authorize running the job
+        """
+        api = self._create_api()
+        job_template = JobTemplateLoader(infile).create_job_template()
+        result = job_template.create_job(api)
+        job_id = result['job']
+        print("Created job {}".format(job_id))
+        if token:
+            api.authorize_job(job_id, token)
+            print("Set run token for job {}".format(job_id))
+        api.start_job(job_id)
+        print("Started job {}".format(job_id))
+
+    def job_validate(self, infile):
+        """
+        Validates a job can be created for the specified job template.
+        :param infile: file: input file to use for creating a job
+        """
+        api = self._create_api()
+        job_template = JobTemplateLoader(infile).create_job_template()
+        job_template.verify_job(api)
+        print("Job file is valid.")
 
     def start_job(self, job_id, token=None):
         """
@@ -125,30 +191,10 @@ class Commands(object):
         item_list = ShareGroupsList(api)
         print(Table(item_list.column_names, item_list.get_column_data()))
 
-    def list_vm_strategies(self):
+    def list_vm_configs(self):
         api = self._create_api()
         item_list = VmStrategiesList(api)
         print(Table(item_list.column_names, item_list.get_column_data()))
-
-    def workflow_configurations_list(self):
-        api = self._create_api()
-        item_list = WorkflowConfigurationsList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
-
-    def create_workflow_configuration(self, name, workflow, default_vm_strategy, joborder_infile):
-        api = self._create_api()
-        joborder = yaml.load(joborder_infile)
-        api.workflow_configurations_post(name, workflow, default_vm_strategy, joborder)
-
-    def list_workflow_versions(self):
-        api = self._create_api()
-        item_list = WorkflowVersionsList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
-
-    def create_workflow_version(self, workflow, version_num, description, url):
-        api = self._create_api()
-        workflow_version = CWLWorkflowVersion(workflow, version_num, description, url)
-        workflow_version.create(api)
 
 
 class Table(object):
@@ -169,15 +215,36 @@ class Table(object):
         return tabulate(column_data, headers=formatted_column_names)
 
 
-class WorkflowDetails(object):
+class ShortWorkflowDetails(object):
+    """
+    Creates column data based on workflows
+    """
+    def __init__(self, api, tag):
+        self.api = api
+        self.tag = tag
+        self.column_names = ["id", "name", "tag"]
+
+    def get_column_data(self):
+        """
+        Return list of dictionaries of workflow data.
+        :return: [dict]: one record for each questionnaire
+        """
+        data = []
+        for workflow in self.api.workflows_list(self.tag):
+            data.append(dict(workflow))
+        return data
+
+
+class FullWorkflowDetails(object):
     """
     Creates column data based on workflows/questionnaires
     """
-    TAG_COLUMN_NAME = "version tag"
+    TAG_COLUMN_NAME = "job template tag"
 
-    def __init__(self, api, all_versions):
+    def __init__(self, api, all_versions, tag):
         self.api = api
         self.all_versions = all_versions
+        self.tag = tag
         self.column_names = ["id", "name", self.TAG_COLUMN_NAME]
 
     def get_column_data(self):
@@ -186,27 +253,71 @@ class WorkflowDetails(object):
         :return: [dict]: one record for each questionnaire
         """
         data = []
-        for workflow in self.api.workflows_list():
+        for workflow in self.api.workflows_list(self.tag):
             if len(workflow['versions']):
                 versions = workflow['versions']
                 if not self.all_versions:
                     versions = versions[-1:]
                 for version_id in versions:
                     workflow_version = self.api.workflow_version_get(version_id)
-                    for workflow_configuration in self.api.workflow_configurations_list(workflow_version=version_id):
+                    configurations = self.api.workflow_configurations_list(workflow_tag=workflow['tag'])
+                    for workflow_configuration in configurations:
                         tag = '{}/{}'.format(workflow_version['tag'], workflow_configuration['tag'])
                         workflow[self.TAG_COLUMN_NAME] = tag
                         data.append(dict(workflow))
         return data
 
 
+class WorkflowVersionsList(object):
+    WORKFLOW_FIELDNAME="workflow tag"
+    def __init__(self, api, workflow_tag):
+        self.api = api
+        self.workflow_tag = workflow_tag
+        self.column_names = ["id", "description", self.WORKFLOW_FIELDNAME, "version", "url"]
+
+    def get_column_data(self):
+        data = []
+        for item in self.api.workflow_versions_list(self.workflow_tag):
+            workflow = self.api.workflow_get(item['workflow'])
+            item[self.WORKFLOW_FIELDNAME] = workflow['tag']
+            data.append(item)
+        return data
+
+
+class WorkflowConfigurationsList(object):
+    WORKFLOW_FIELDNAME = "workflow"
+    SHARE_GROUP_FIELDNAME = "share group"
+    DEFAULT_VM_STRATEGY_FIELDNAME = "Default VM Strategy"
+    def __init__(self, api, workflow_tag):
+        self.api = api
+        self.workflow_tag = workflow_tag
+        self.column_names = ["id", "tag", self.WORKFLOW_FIELDNAME, self.SHARE_GROUP_FIELDNAME,
+                             self.DEFAULT_VM_STRATEGY_FIELDNAME]
+
+    def get_column_data(self):
+        data = []
+        for item in self.api.workflow_configurations_list(workflow_tag=self.workflow_tag):
+            self.add_new_fields(item)
+            data.append(item)
+        return data
+
+    def add_new_fields(self, item):
+        workflow = self.api.workflow_get(item['workflow'])
+        item[self.WORKFLOW_FIELDNAME] = workflow['tag']
+        share_group = self.api.share_group_get(item['share_group'])
+        item[self.SHARE_GROUP_FIELDNAME] = share_group['name']
+        vm_strategy = self.api.vm_strategy_get(item['default_vm_strategy'])
+        item[self.DEFAULT_VM_STRATEGY_FIELDNAME] = vm_strategy['name']
+
+
 class JobsList(object):
+    WORKFLOW_VERSION_TAG = "workflow_version_tag"
     """
     Creates column data based on current users's jobs
     """
     def __init__(self, api):
         self.api = api
-        self.column_names = ["id", "name", "state", "step", "last_updated", "elapsed_hours", "workflow_tag"]
+        self.column_names = ["id", "name", "state", "step", "last_updated", "elapsed_hours", self.WORKFLOW_VERSION_TAG]
 
     def get_column_data(self):
         """
@@ -216,18 +327,13 @@ class JobsList(object):
         data = []
         for job in self.api.jobs_list():
             job['elapsed_hours'] = self.get_elapsed_hours(job.get('usage'))
-            job['workflow_tag'] = self.get_workflow_tag(job['workflow_version'])
+            job[self.WORKFLOW_VERSION_TAG] = self.get_workflow_version_tag(job['workflow_version'])
             data.append(job)
         return data
 
-    def get_workflow_tag(self, workflow_version):
-        """
-        Lookup the workflow tag for the specified workflow version
-        :param workflow_version: int: workflow version id to lookup tag for
-        :return: str: tag associated with workflow_version
-        """
-        configurations = self.api.workflow_configurations_list(workflow_version=workflow_version)
-        return configurations[0]['tag']
+    def get_workflow_version_tag(self, workflow_version_id):
+        workflow_version = self.api.workflow_version_get(workflow_version_id)
+        return workflow_version['tag']
 
     def get_elapsed_hours(self, usage):
         if usage:
@@ -276,54 +382,3 @@ class VmStrategiesList(object):
 
         volume_size_format = "{} x Input Data Size + {}"
         item[self.VOLUME_SIZE_FIELDNAME] = volume_size_format.format(volume_size_factor, volume_size_base)
-
-
-class WorkflowConfigurationsList(object):
-    WORKFLOW_FIELDNAME = "workflow"
-    SHARE_GROUP_FIELDNAME = "share group"
-    DEFAULT_VM_STRATEGY_FIELDNAME = "Default VM Strategy"
-    def __init__(self, api):
-        self.api = api
-        self.column_names = ["id", "tag", self.WORKFLOW_FIELDNAME, self.SHARE_GROUP_FIELDNAME,
-                             self.DEFAULT_VM_STRATEGY_FIELDNAME]
-
-    def get_column_data(self):
-        data = []
-        for item in self.api.workflow_configurations_list():
-            self.add_new_fields(item)
-            data.append(item)
-        return data
-
-    def add_new_fields(self, item):
-        workflow = self.api.workflow_get(item['workflow'])
-        self.add_field(item, self.WORKFLOW_FIELDNAME, workflow, 'tag')
-        share_group = self.api.share_group_get(item['share_group'])
-        self.add_field(item, self.SHARE_GROUP_FIELDNAME, share_group, 'name')
-        vm_strategy = self.api.vm_strategy_get(item['default_vm_strategy'])
-        self.add_field(item, self.DEFAULT_VM_STRATEGY_FIELDNAME, vm_strategy, 'name')
-
-    @staticmethod
-    def add_field(dest, dest_fieldname, source, source_fieldname):
-        dest[dest_fieldname] = "{} ({})".format(source[source_fieldname], source['id'])
-
-
-class WorkflowVersionsList(object):
-    WORKFLOW_FIELDNAME="workflow"
-    def __init__(self, api):
-        self.api = api
-        self.column_names = ["id", "description", self.WORKFLOW_FIELDNAME, "version", "url"]
-
-    def get_column_data(self):
-        data = []
-        for item in self.api.workflow_versions_list():
-            self.add_new_fields(item)
-            data.append(item)
-        return data
-
-    def add_new_fields(self, item):
-        workflow = self.api.workflow_get(item['workflow'])
-        self.add_field(item, self.WORKFLOW_FIELDNAME, workflow, 'tag')
-
-    @staticmethod
-    def add_field(dest, dest_fieldname, source, source_fieldname):
-        dest[dest_fieldname] = "{} ({})".format(source[source_fieldname], source['id'])

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -113,7 +113,7 @@ class Commands(object):
         outfile.write(yaml.dump(job_file, default_flow_style=False))
         if outfile != sys.stdout:
             print("Wrote job file {}.".format(outfile.name))
-            print("Edit this file filling in TODO fields then run `bespin jobs create {}` .".format(outfile.name))
+            print("Edit this file filling in TODO fields then run `bespin job create {}` .".format(outfile.name))
 
     def job_create(self, job_template_infile):
         """
@@ -126,7 +126,7 @@ class Commands(object):
         result = job_template.create_job(api)
         job_id = result['job']
         print("Created job {}".format(job_id))
-        print("To start this job run `bespin jobs start {}` .".format(job_id))
+        print("To start this job run `bespin job start {}` .".format(job_id))
 
     def job_run(self, job_template_infile, token=None):
         """

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -87,12 +87,12 @@ class Commands(object):
     def share_groups_list(self):
         api = self._create_api()
         item_list = ShareGroupsList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
+        self._print_details_as_table(item_list)
 
     def vm_configs_list(self):
         api = self._create_api()
         item_list = VmStrategiesList(api)
-        print(Table(item_list.column_names, item_list.get_column_data()))
+        self._print_details_as_table(item_list)
 
     def jobs_list(self):
         """
@@ -100,7 +100,7 @@ class Commands(object):
         """
         api = self._create_api()
         jobs_list = JobsList(api)
-        print(Table(jobs_list.column_names, jobs_list.get_column_data()))
+        self._print_details_as_table(jobs_list)
 
     def job_template_create(self, tag, outfile):
         """
@@ -195,7 +195,6 @@ class Commands(object):
         api = self._create_api()
         api.delete_job(job_id)
         print("Deleted job {}".format(job_id))
-
 
 
 class Table(object):

--- a/bespin/exceptions.py
+++ b/bespin/exceptions.py
@@ -25,3 +25,15 @@ class JobDoesNotExistException(UserInputException):
 
 class WorkflowConfigurationNotFoundException(UserInputException):
     pass
+
+
+class WorkflowNotFound(UserInputException):
+    pass
+
+
+class ShareGroupNotFound(UserInputException):
+    pass
+
+
+class VMStrategyNotFound(UserInputException):
+    pass

--- a/bespin/exceptions.py
+++ b/bespin/exceptions.py
@@ -3,7 +3,7 @@ class UserInputException(Exception):
     pass
 
 
-class IncompleteJobFileException(UserInputException):
+class IncompleteJobTemplateException(UserInputException):
     pass
 
 

--- a/bespin/jobtemplate.py
+++ b/bespin/jobtemplate.py
@@ -1,0 +1,268 @@
+from bespin.exceptions import IncompleteJobTemplateException, WorkflowConfigurationNotFoundException
+from bespin.dukeds import DDSFileUtil
+from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
+import yaml
+
+STRING_VALUE_PLACEHOLDER = "<String Value>"
+INT_VALUE_PLACEHOLDER = "<Integer Value>"
+FILE_PLACEHOLDER = "dds://<Project Name>/<File Path>"
+USER_PLACEHOLDER_VALUES = [STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, FILE_PLACEHOLDER]
+USER_PLACEHOLDER_DICT = {
+    'File': {
+        "class": "File",
+        "path": FILE_PLACEHOLDER
+    },
+    'int': INT_VALUE_PLACEHOLDER,
+    'string': STRING_VALUE_PLACEHOLDER,
+    'NamedFASTQFilePairType': {
+        "name": STRING_VALUE_PLACEHOLDER,
+        "file1": {
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        },
+        "file2": {
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        }
+    },
+    'FASTQReadPairType': {
+        "name": STRING_VALUE_PLACEHOLDER,
+        "read1_files": [{
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        }],
+        "read2_files": [{
+            "class": "File",
+            "path": FILE_PLACEHOLDER
+        }]
+    }
+}
+
+
+class JobTemplate(object):
+    """
+    Contains data for creating a job.
+    """
+    def __init__(self, tag, name, fund_code, job_order, job_vm_strategy_id=None):
+        self.tag = tag
+        self.name = name
+        self.fund_code = fund_code
+        self.job_order = job_order
+        self.job_vm_strategy_id = job_vm_strategy_id
+        self.stage_group_id = None
+
+    def to_dict(self):
+        data = {
+            'name': self.name,
+            'fund_code': self.fund_code,
+            'job_order': self.job_order,
+            'tag': self.tag,
+        }
+        if self.stage_group_id:
+            data['stage_group'] = self.stage_group_id
+        if self.job_vm_strategy_id:
+            data['job_vm_strategy'] = self.job_vm_strategy_id
+        return data
+
+    def create_user_job_order(self):
+        """
+        Format job order replacing dds remote file paths with filenames that will be staged
+        :return: dict: job order for running CWL
+        """
+        user_job_order = self.job_order.copy()
+        formatter = JobOrderFormatFiles()
+        formatter.walk(user_job_order)
+        return user_job_order
+
+    def get_dds_files_details(self):
+        """
+        Get dds files info based on job_order
+        :return: [(dds_file, staging_filename)]
+        """
+        job_order_details = JobOrderFileDetails()
+        job_order_details.walk(self.job_order)
+        return job_order_details.dds_files
+
+    def read_workflow_configuration(self, api):
+        workflow_configurations = api.workflow_configurations_list(tag=self.tag)
+        if workflow_configurations:
+            return workflow_configurations[0]
+        raise WorkflowConfigurationNotFoundException(
+            "Unable to find workflow configuration for tag {}".format(self.tag)
+        )
+
+    def create_job(self, api):
+        """
+        Create a job using the passed on api
+        :param api: BespinApi
+        :return: dict: job dictionary returned from bespin api
+        """
+        dds_user_credential = api.dds_user_credentials_list()[0]
+        self.read_workflow_configuration(api)
+        stage_group = api.stage_group_post()
+        self.stage_group_id = stage_group['id']
+        dds_project_ids = set()
+        sequence = 0
+        for dds_file, path in self.get_dds_files_details():
+            file_size = dds_file.current_version['upload']['size']
+            api.dds_job_input_files_post(dds_file.project_id, dds_file.id, path, 0, sequence,
+                                         dds_user_credential['id'], stage_group_id=self.stage_group_id,
+                                         size=file_size)
+            sequence += 1
+            dds_project_ids.add(dds_file.project_id)
+        self.job_order = self.create_user_job_order()
+        job = api.job_templates_create_job(self.to_dict())
+        dds_file_util = DDSFileUtil()
+        for project_id in dds_project_ids:
+            dds_file_util.give_download_permissions(project_id, dds_user_credential['dds_id'])
+        return job
+
+    def verify_job(self, api):
+        self.read_workflow_configuration(api)  # workflow configuration must exist
+        self.get_dds_files_details()  # DukeDS input files must exist
+        self.create_user_job_order()  # verify that we can generate a job order
+
+
+class JobTemplateLoader(object):
+    """
+    Creates JobFile based on an input file
+    """
+    def __init__(self, infile):
+        self.data = yaml.load(infile)
+
+    def create_job_template(self, vm_strategy_id):
+        self.validate_job_file_data()
+        job_template = JobTemplate(tag=self.data['tag'],
+                                   name=self.data['name'],
+                                   fund_code=self.data['fund_code'],
+                                   job_order=self.data['job_order'],
+                                   job_vm_strategy_id=vm_strategy_id)
+        return job_template
+
+    def validate_job_file_data(self):
+        bad_fields = []
+        for field_name in ['name', 'fund_code']:
+            if self.data[field_name] in USER_PLACEHOLDER_VALUES:
+                bad_fields.append(field_name)
+        checker = JobOrderPlaceholderCheck()
+        checker.walk(self.data['job_order'])
+        bad_fields.extend(['job_order.{}'.format(key) for key in checker.keys_with_placeholders])
+        if bad_fields:
+            bad_fields.sort()
+            bad_fields_str = ', '.join(bad_fields)
+            error_msg = "Please fill in placeholder values for field(s): {}".format(bad_fields_str)
+            raise IncompleteJobTemplateException(error_msg)
+
+
+class JobConfiguration(object):
+    """
+    Creates a placeholder job file based on workflow_configuration
+    """
+    def __init__(self, workflow_configuration):
+        self.workflow_configuration = workflow_configuration
+
+    def create_job_template_with_placeholders(self):
+        return JobTemplate(tag=self.workflow_configuration['tag'],
+                           name=STRING_VALUE_PLACEHOLDER, fund_code=STRING_VALUE_PLACEHOLDER,
+                           job_order=self.format_user_fields())
+
+    def format_user_fields(self):
+        user_fields = self.workflow_configuration['user_fields']
+        formatted_user_fields = {}
+        for user_field in user_fields:
+            field_type = user_field.get('type')
+            field_name = user_field.get('name')
+            if isinstance(field_type, dict):
+                if field_type['type'] == 'array':
+                    value = self.create_placeholder_value(field_type['items'], is_array=True)
+                else:
+                    value = self.create_placeholder_value(field_type['type'], is_array=False)
+            else:
+                value = self.create_placeholder_value(field_type, is_array=False)
+            formatted_user_fields[field_name] = value
+        return formatted_user_fields
+
+    def create_placeholder_value(self, type_name, is_array):
+        if is_array:
+            return [self.create_placeholder_value(type_name, is_array=False)]
+        else:  # single item type
+            placeholder = USER_PLACEHOLDER_DICT.get(type_name)
+            if not placeholder:
+                return STRING_VALUE_PLACEHOLDER
+            return placeholder
+
+
+class JobOrderWalker(object):
+    def walk(self, obj):
+        for key in obj.keys():
+            self._walk_job_order(key, obj[key])
+
+    def _walk_job_order(self, top_level_key, obj):
+        if self._is_list_but_not_string(obj):
+            return [self._walk_job_order(top_level_key, item) for item in obj]
+        elif isinstance(obj, dict):
+            if 'class' in obj.keys():
+                self.on_class_value(top_level_key, obj)
+            else:
+                for key in obj:
+                    self._walk_job_order(top_level_key, obj[key])
+        else:
+            # base object string or int or something
+            self.on_simple_value(top_level_key, obj)
+
+    @staticmethod
+    def _is_list_but_not_string(obj):
+        return isinstance(obj, list) and not isinstance(obj, str)
+
+    def on_class_value(self, top_level_key, value):
+        pass
+
+    def on_simple_value(self, top_level_key, value):
+        pass
+
+    @staticmethod
+    def format_file_path(path):
+        """
+        Create a valid file path based on a dds placeholder url
+        :param path: str: format dds://<projectname>/<filepath>
+        :return: str: file path to be used for staging data when running the workflow
+        """
+        if path.startswith(DUKEDS_PATH_PREFIX):
+            return path.replace(DUKEDS_PATH_PREFIX, "dds_").replace("/", "_").replace(":", "_")
+        return path
+
+
+class JobOrderPlaceholderCheck(JobOrderWalker):
+    def __init__(self):
+        self.keys_with_placeholders = set()
+
+    def on_class_value(self, top_level_key, value):
+        if value['class'] == 'File':
+            path = value.get('path')
+            if path and path in USER_PLACEHOLDER_VALUES:
+                self.keys_with_placeholders.add(top_level_key)
+
+    def on_simple_value(self, top_level_key, value):
+        if value in USER_PLACEHOLDER_VALUES:
+            self.keys_with_placeholders.add(top_level_key)
+
+
+class JobOrderFormatFiles(JobOrderWalker):
+    def on_class_value(self, top_level_key, value):
+        if value['class'] == 'File':
+            path = value.get('path')
+            if path:
+                value['path'] = self.format_file_path(path)
+
+
+class JobOrderFileDetails(JobOrderWalker):
+    def __init__(self):
+        self.dds_file_util = DDSFileUtil()
+        self.dds_files = []
+
+    def on_class_value(self, top_level_key, value):
+        if value['class'] == 'File':
+            path = value.get('path')
+            if path and path.startswith(DUKEDS_PATH_PREFIX):
+                dds_file = self.dds_file_util.find_file_for_path(path)
+                self.dds_files.append((dds_file, self.format_file_path(path)))

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -66,6 +66,18 @@ class BespinApiTestCase(TestCase):
         mock_requests.get.assert_called_with('someurl/workflows/', headers=self.expected_headers)
 
     @patch('bespin.api.requests')
+    def test_workflows_get(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'workflow1'
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflow = api.workflow_get('12')
+
+        self.assertEqual(workflow, 'workflow1')
+        mock_requests.get.assert_called_with('someurl/workflows/12/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
     def test_workflow_versions_list(self, mock_requests):
         mock_response = Mock()
         mock_response.json.return_value = ['workflowversion1', 'workflowversion2']
@@ -88,6 +100,26 @@ class BespinApiTestCase(TestCase):
 
         self.assertEqual(item, 'workflowversion1')
         mock_requests.get.assert_called_with('someurl/workflow-versions/123/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_versions_post(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'worflow_version1'
+        mock_requests.post.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        worflow_version = api.workflow_versions_post(workflow=1, version_num=2, description="my desc", url="someurl2",
+                                                 fields=[])
+        self.assertEqual(worflow_version, 'worflow_version1')
+        expected_post_payload = {
+            'workflow': 1,
+            'version': 2,
+            'description': 'my desc',
+            'url': 'someurl2',
+            'fields': []
+        }
+        mock_requests.post.assert_called_with('someurl/admin/workflow-versions/', headers=self.expected_headers,
+                                              json=expected_post_payload)
 
     @patch('bespin.api.requests')
     def test_stage_group_post(self, mock_requests):
@@ -225,6 +257,39 @@ class BespinApiTestCase(TestCase):
         self.assertEqual(items, ['workflowconfig1'])
 
     @patch('bespin.api.requests')
+    def test_workflow_configurations_get(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'workflow1'
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflow = api.workflow_configurations_get('12')
+
+        self.assertEqual(workflow, 'workflow1')
+        mock_requests.get.assert_called_with('someurl/workflow-configurations/12/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_configurations_post(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'workflowconfiguration1'
+        mock_requests.post.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflow_configuration = api.workflow_configurations_post(name='myconfig', workflow=1, default_vm_strategy=2,
+                                                                  system_job_order={})
+
+        self.assertEqual(workflow_configuration, 'workflowconfiguration1')
+        expected_post_payload = {
+            'name': 'myconfig',
+            'workflow': 1,
+            'default_vm_strategy': 2,
+            'system_job_order': {}
+        }
+        mock_requests.post.assert_called_with('someurl/admin/workflow-configurations/',
+                                              headers=self.expected_headers,
+                                              json=expected_post_payload)
+
+    @patch('bespin.api.requests')
     def test_workflow_configurations_create_job(self, mock_requests):
         mock_response = Mock()
         mock_response.json.return_value = ['workflowconfig1']
@@ -246,3 +311,32 @@ class BespinApiTestCase(TestCase):
         mock_requests.post.assert_called_with('someurl/workflow-configurations/1/create-job/',
                                               headers=self.expected_headers,
                                               json=expected_json)
+
+    @patch('bespin.api.requests')
+    def test_job_templates_init(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'job_template1'
+        mock_requests.post.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        result = api.job_templates_init(tag="exome/v1/human")
+        self.assertEqual(result, 'job_template1')
+        expected_post_payload = {
+            'tag': 'exome/v1/human'
+        }
+        mock_requests.post.assert_called_with('someurl/job-templates/init/',
+                                              headers=self.expected_headers,
+                                              json=expected_post_payload)
+
+    @patch('bespin.api.requests')
+    def test_job_templates_create_job(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'job_template_filled_in'
+        mock_requests.post.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        result = api.job_templates_create_job(job_file_payload={'a': '1'})
+        self.assertEqual(result, 'job_template_filled_in')
+        mock_requests.post.assert_called_with('someurl/job-templates/create-job/',
+                                              headers=self.expected_headers,
+                                              json={'a': '1'})

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -251,8 +251,11 @@ class BespinApiTestCase(TestCase):
         mock_requests.get.return_value = mock_response
 
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
-        items = api.workflow_configurations_list(workflow_version=12, tag='mytag')
-        mock_requests.get.assert_called_with('someurl/workflow-configurations/?workflow_version=12&tag=mytag',
+        items = api.workflow_configurations_list(tag="sometag", workflow=1, workflow_tag="wftag")
+        mock_requests.get.assert_called_with('someurl/workflow-configurations/?'
+                                             'tag=sometag&'
+                                             'workflow=1&'
+                                             'workflow__tag=wftag',
                                              headers=self.expected_headers)
         self.assertEqual(items, ['workflowconfig1'])
 
@@ -275,14 +278,17 @@ class BespinApiTestCase(TestCase):
         mock_requests.post.return_value = mock_response
 
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
-        workflow_configuration = api.workflow_configurations_post(name='myconfig', workflow=1, default_vm_strategy=2,
+        workflow_configuration = api.workflow_configurations_post(tag='myconfig', workflow=1,
+                                                                  share_group=2,
+                                                                  default_vm_strategy=3,
                                                                   system_job_order={})
 
         self.assertEqual(workflow_configuration, 'workflowconfiguration1')
         expected_post_payload = {
-            'name': 'myconfig',
+            'tag': 'myconfig',
             'workflow': 1,
-            'default_vm_strategy': 2,
+            'share_group': 2,
+            'default_vm_strategy': 3,
             'system_job_order': {}
         }
         mock_requests.post.assert_called_with('someurl/admin/workflow-configurations/',

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -66,7 +66,19 @@ class BespinApiTestCase(TestCase):
         mock_requests.get.assert_called_with('someurl/workflows/', headers=self.expected_headers)
 
     @patch('bespin.api.requests')
-    def test_workflows_get(self, mock_requests):
+    def test_workflows_list_with_filter(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['workflow1', 'workflow2']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflows = api.workflows_list(tag="mytag")
+
+        self.assertEqual(workflows, ['workflow1', 'workflow2'])
+        mock_requests.get.assert_called_with('someurl/workflows/?tag=mytag', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_get(self, mock_requests):
         mock_response = Mock()
         mock_response.json.return_value = 'workflow1'
         mock_requests.get.return_value = mock_response
@@ -76,6 +88,31 @@ class BespinApiTestCase(TestCase):
 
         self.assertEqual(workflow, 'workflow1')
         mock_requests.get.assert_called_with('someurl/workflows/12/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_get_for_tag(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['workflow1']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflow = api.workflow_get_for_tag(workflow_tag='exomeseq')
+
+        self.assertEqual(workflow, 'workflow1')
+        mock_requests.get.assert_called_with('someurl/workflows/?tag=exomeseq', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_post(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'workflow1'
+        mock_requests.post.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        workflow = api.workflow_post(name="myname", tag="mytag")
+
+        self.assertEqual(workflow, 'workflow1')
+        mock_requests.post.assert_called_with('someurl/admin/workflows/', headers=self.expected_headers,
+                                              json={'name': 'myname', 'tag': 'mytag'})
 
     @patch('bespin.api.requests')
     def test_workflow_versions_list(self, mock_requests):
@@ -88,6 +125,19 @@ class BespinApiTestCase(TestCase):
 
         self.assertEqual(items, ['workflowversion1', 'workflowversion2'])
         mock_requests.get.assert_called_with('someurl/workflow-versions/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_workflow_versions_list_with_filter(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['workflowversion1', 'workflowversion2']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        items = api.workflow_versions_list(workflow_tag='exomeseq')
+
+        self.assertEqual(items, ['workflowversion1', 'workflowversion2'])
+        mock_requests.get.assert_called_with('someurl/workflow-versions/?workflow__tag=exomeseq',
+                                             headers=self.expected_headers)
 
     @patch('bespin.api.requests')
     def test_workflow_version_get(self, mock_requests):
@@ -296,29 +346,6 @@ class BespinApiTestCase(TestCase):
                                               json=expected_post_payload)
 
     @patch('bespin.api.requests')
-    def test_workflow_configurations_create_job(self, mock_requests):
-        mock_response = Mock()
-        mock_response.json.return_value = ['workflowconfig1']
-        mock_requests.get.return_value = mock_response
-        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
-        item = api.workflow_configurations_create_job(
-            workflow_configuration_id=1,
-            job_name='myjob',
-            fund_code='001',
-            stage_group=1,
-            user_job_order={'threads': 12},
-            job_vm_strategy=2)
-        expected_json = {
-            'job_name': 'myjob',
-            'fund_code': '001',
-            'stage_group': 1,
-            'user_job_order': {'threads': 12},
-            'job_vm_strategy': 2}
-        mock_requests.post.assert_called_with('someurl/workflow-configurations/1/create-job/',
-                                              headers=self.expected_headers,
-                                              json=expected_json)
-
-    @patch('bespin.api.requests')
     def test_job_templates_init(self, mock_requests):
         mock_response = Mock()
         mock_response.json.return_value = 'job_template1'
@@ -346,3 +373,75 @@ class BespinApiTestCase(TestCase):
         mock_requests.post.assert_called_with('someurl/job-templates/create-job/',
                                               headers=self.expected_headers,
                                               json={'a': '1'})
+
+    @patch('bespin.api.requests')
+    def test_share_groups_list(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['sharegroup1']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.share_groups_list(name='somename')
+
+        self.assertEqual(response, ['sharegroup1'])
+        mock_requests.get.assert_called_with('someurl/share-groups/?name=somename', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_share_group_get(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'sharegroup1'
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.share_group_get(123)
+
+        self.assertEqual(response, 'sharegroup1')
+        mock_requests.get.assert_called_with('someurl/share-groups/123/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_share_group_get_for_name(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['sharegroup1']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.share_group_get_for_name(name='myname')
+
+        self.assertEqual(response, 'sharegroup1')
+        mock_requests.get.assert_called_with('someurl/share-groups/?name=myname', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_vm_strategies_list(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['vmstrategy1']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.vm_strategies_list(name='somename')
+
+        self.assertEqual(response, ['vmstrategy1'])
+        mock_requests.get.assert_called_with('someurl/vm-strategies/?name=somename', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_vm_strategy_get(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = 'vmstrategy1'
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.vm_strategy_get(123)
+
+        self.assertEqual(response, 'vmstrategy1')
+        mock_requests.get.assert_called_with('someurl/vm-strategies/123/', headers=self.expected_headers)
+
+    @patch('bespin.api.requests')
+    def test_vm_strategy_get_for_name(self, mock_requests):
+        mock_response = Mock()
+        mock_response.json.return_value = ['vmstrategy1']
+        mock_requests.get.return_value = mock_response
+
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        response = api.vm_strategy_get_for_name(name='myname')
+
+        self.assertEqual(response, 'vmstrategy1')
+        mock_requests.get.assert_called_with('someurl/vm-strategies/?name=myname', headers=self.expected_headers)

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -14,16 +14,12 @@ class ArgParserTestCase(TestCase):
         self.arg_parser.parse_and_run_commands(["workflow", "list"])
         self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=False, tag=None)
 
-    def test_wf_list_current_versions(self):
-        self.arg_parser.parse_and_run_commands(["wf", "list"])
-        self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=False, tag=None)
-
-    def test_wf_list_all_versions(self):
-        self.arg_parser.parse_and_run_commands(["wf", "list", "--all"])
+    def test_workflow_list_all_versions(self):
+        self.arg_parser.parse_and_run_commands(["workflow", "list", "--all"])
         self.target_object.workflows_list.assert_called_with(all_versions=True, short_format=False, tag=None)
 
-    def test_wf_list_short(self):
-        self.arg_parser.parse_and_run_commands(["wf", "list", "--short"])
+    def test_workflow_list_short(self):
+        self.arg_parser.parse_and_run_commands(["workflow", "list", "--short"])
         self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=True, tag=None)
 
     def test_workflows_create(self):
@@ -32,10 +28,6 @@ class ArgParserTestCase(TestCase):
 
     def test_workflow_versions_list(self):
         self.arg_parser.parse_and_run_commands(["workflow-version", "list"])
-        self.target_object.workflow_versions_list.assert_called_with(workflow_tag=None)
-
-    def test_wfv_versions_list(self):
-        self.arg_parser.parse_and_run_commands(["wfv", "list"])
         self.target_object.workflow_versions_list.assert_called_with(workflow_tag=None)
 
     def test_workflow_versions_list_with_filter(self):
@@ -59,16 +51,12 @@ class ArgParserTestCase(TestCase):
         self.arg_parser.parse_and_run_commands(["workflow-config", "list"])
         self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)
 
-    def test_wfc_config_list(self):
-        self.arg_parser.parse_and_run_commands(["wfc", "list"])
-        self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)
-
     def test_workflow_config_list_with_filter(self):
         self.arg_parser.parse_and_run_commands(["workflow-config", "list", "--workflow", "sometag"])
         self.target_object.workflow_configs_list.assert_called_with(workflow_tag="sometag")
 
-    def test_wfc_config_show_job_order(self):
-        self.arg_parser.parse_and_run_commands(["wfc", "show-job-order",
+    def test_workflow_config_config_show_job_order(self):
+        self.arg_parser.parse_and_run_commands(["workflow-config", "show-job-order",
                                                 "--workflow", "sometag",
                                                 "--tag", "mytag"])
         self.target_object.workflow_config_show_job_order.assert_called_with(tag='mytag',
@@ -94,32 +82,16 @@ class ArgParserTestCase(TestCase):
         self.arg_parser.parse_and_run_commands(["share-group", "list"])
         self.target_object.share_groups_list.assert_called_with()
 
-    def test_sg_list(self):
-        self.arg_parser.parse_and_run_commands(["sg", "list"])
-        self.target_object.share_groups_list.assert_called_with()
-
     def test_vm_config_list(self):
         self.arg_parser.parse_and_run_commands(["vm-config", "list"])
-        self.target_object.vm_configs_list.assert_called_with()
-
-    def test_vmc_list(self):
-        self.arg_parser.parse_and_run_commands(["vmc", "list"])
         self.target_object.vm_configs_list.assert_called_with()
 
     def test_job_template_create(self):
         self.arg_parser.parse_and_run_commands(["job-template", "create", "sometag/v1/human"])
         self.target_object.job_template_create.assert_called_with(tag='sometag/v1/human', outfile=sys.stdout)
 
-    def test_job_template_create(self):
-        self.arg_parser.parse_and_run_commands(["jt", "create", "sometag/v1/human"])
-        self.target_object.job_template_create.assert_called_with(tag='sometag/v1/human', outfile=sys.stdout)
-
     def test_job_list(self):
         self.arg_parser.parse_and_run_commands(["job", "list"])
-        self.target_object.jobs_list.assert_called_with()
-
-    def test_j_list(self):
-        self.arg_parser.parse_and_run_commands(["j", "list"])
         self.target_object.jobs_list.assert_called_with()
 
     def test_job_create(self):

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -26,9 +26,9 @@ class ArgParserTestCase(TestCase):
         self.arg_parser.parse_and_run_commands(["workflows", "configurations", "job-order", "3"])
         self.target_object.workflow_configuration_job_order_show.assert_called_with(3, sys.stdout)
 
-    def test_init_job(self):
+    def test_job_template_init(self):
         self.arg_parser.parse_and_run_commands(["jobs", "init", "exome/v1/human"])
-        self.target_object.init_job.assert_called_with("exome/v1/human", sys.stdout)
+        self.target_object.job_template_init.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_create_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py"])

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from bespin.argparser import ArgParser
-from mock import patch, Mock, ANY
+from mock import patch, Mock, ANY, mock_open
 import sys
 
 
@@ -11,53 +11,153 @@ class ArgParserTestCase(TestCase):
         self.arg_parser = ArgParser(version_str='1.0', target_object=self.target_object)
 
     def test_workflows_list_current_versions(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "list"])
-        self.target_object.workflows_list.assert_called_with(all_versions=False)
+        self.arg_parser.parse_and_run_commands(["workflow", "list"])
+        self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=False, tag=None)
 
-    def test_workflows_list_all_versions(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "list", "--all"])
-        self.target_object.workflows_list.assert_called_with(all_versions=True)
+    def test_wf_list_current_versions(self):
+        self.arg_parser.parse_and_run_commands(["wf", "list"])
+        self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=False, tag=None)
 
-    def test_workflows_list_all_versions_short_flag(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "list", "-a"])
-        self.target_object.workflows_list.assert_called_with(all_versions=True)
+    def test_wf_list_all_versions(self):
+        self.arg_parser.parse_and_run_commands(["wf", "list", "--all"])
+        self.target_object.workflows_list.assert_called_with(all_versions=True, short_format=False, tag=None)
 
-    def test_workflow_configuration_show_joborder(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "configurations", "job-order", "3"])
-        self.target_object.workflow_configuration_job_order_show.assert_called_with(3, sys.stdout)
+    def test_wf_list_short(self):
+        self.arg_parser.parse_and_run_commands(["wf", "list", "--short"])
+        self.target_object.workflows_list.assert_called_with(all_versions=False, short_format=True, tag=None)
 
-    def test_job_template_init(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "init", "exome/v1/human"])
-        self.target_object.job_template_init.assert_called_with("exome/v1/human", sys.stdout)
+    def test_workflows_create(self):
+        self.arg_parser.parse_and_run_commands(["workflow", "create", "--name", "MyWF", "--tag", "sometag"])
+        self.target_object.workflows_list.workflow_create(name="MyWF", tag="sometag")
 
-    def test_create_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py"])
-        self.target_object.create_job.assert_called_with(ANY, False, None)
+    def test_workflow_versions_list(self):
+        self.arg_parser.parse_and_run_commands(["workflow-version", "list"])
+        self.target_object.workflow_versions_list.assert_called_with(workflow_tag=None)
 
-    def test_create_job_dry_run(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run"])
-        self.target_object.create_job.assert_called_with(ANY, True, None)
+    def test_wfv_versions_list(self):
+        self.arg_parser.parse_and_run_commands(["wfv", "list"])
+        self.target_object.workflow_versions_list.assert_called_with(workflow_tag=None)
 
-    def test_create_job_with_vm_strategy(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--vm-strategy", "2"])
-        self.target_object.create_job.assert_called_with(ANY, False, '2')
+    def test_workflow_versions_list_with_filter(self):
+        self.arg_parser.parse_and_run_commands(["workflow-version", "list", "--workflow", "sometag"])
+        self.target_object.workflow_versions_list.assert_called_with(workflow_tag="sometag")
+
+    def test_workflow_versions_create(self):
+        self.arg_parser.parse_and_run_commands(["workflow-version", "create",
+                                                "--workflow", "sometag",
+                                                "--url", "someurl",
+                                                "--description", "SomeDesc",
+                                                "--version", "auto"])
+        self.target_object.workflow_version_create.assert_called_with(
+            workflow_tag="sometag",
+            url="someurl",
+            description="SomeDesc",
+            version="auto"
+        )
+
+    def test_workflow_config_list(self):
+        self.arg_parser.parse_and_run_commands(["workflow-config", "list"])
+        self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)
+
+    def test_wfc_config_list(self):
+        self.arg_parser.parse_and_run_commands(["wfc", "list"])
+        self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)
+
+    def test_workflow_config_list_with_filter(self):
+        self.arg_parser.parse_and_run_commands(["workflow-config", "list", "--workflow", "sometag"])
+        self.target_object.workflow_configs_list.assert_called_with(workflow_tag="sometag")
+
+    def test_wfc_config_show_job_order(self):
+        self.arg_parser.parse_and_run_commands(["wfc", "show-job-order",
+                                                "--workflow", "sometag",
+                                                "--tag", "mytag"])
+        self.target_object.workflow_config_show_job_order.assert_called_with(tag='mytag',
+                                                                             workflow_tag='sometag',
+                                                                             outfile=sys.stdout)
+
+    def test_workflow_config_create(self):
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.arg_parser.parse_and_run_commands(["workflow-config", "create",
+                                                    "--workflow", "sometag",
+                                                    "--default-vm-config", "default2",
+                                                    "--share-group", "informatics",
+                                                    "--tag", "newtag",
+                                                    "job_order.json"])
+        self.target_object.workflow_config_create.assert_called_with(
+            workflow_tag='sometag',
+            default_vm_strategy_name='default2',
+            share_group_name='informatics',
+            tag='newtag',
+            joborder_infile=ANY)
+
+    def test_share_group_list(self):
+        self.arg_parser.parse_and_run_commands(["share-group", "list"])
+        self.target_object.share_groups_list.assert_called_with()
+
+    def test_sg_list(self):
+        self.arg_parser.parse_and_run_commands(["sg", "list"])
+        self.target_object.share_groups_list.assert_called_with()
+
+    def test_vm_config_list(self):
+        self.arg_parser.parse_and_run_commands(["vm-config", "list"])
+        self.target_object.vm_configs_list.assert_called_with()
+
+    def test_vmc_list(self):
+        self.arg_parser.parse_and_run_commands(["vmc", "list"])
+        self.target_object.vm_configs_list.assert_called_with()
+
+    def test_job_template_create(self):
+        self.arg_parser.parse_and_run_commands(["job-template", "create", "sometag/v1/human"])
+        self.target_object.job_template_create.assert_called_with(tag='sometag/v1/human', outfile=sys.stdout)
+
+    def test_job_template_create(self):
+        self.arg_parser.parse_and_run_commands(["jt", "create", "sometag/v1/human"])
+        self.target_object.job_template_create.assert_called_with(tag='sometag/v1/human', outfile=sys.stdout)
+
+    def test_job_list(self):
+        self.arg_parser.parse_and_run_commands(["job", "list"])
+        self.target_object.jobs_list.assert_called_with()
+
+    def test_j_list(self):
+        self.arg_parser.parse_and_run_commands(["j", "list"])
+        self.target_object.jobs_list.assert_called_with()
+
+    def test_job_create(self):
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.arg_parser.parse_and_run_commands(["job", "create", "job_template.yaml"])
+        self.target_object.job_create.assert_called_with(job_template_infile=mock_file.return_value)
+
+    def test_job_run(self):
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.arg_parser.parse_and_run_commands(["job", "run", "job_template.yaml"])
+        self.target_object.job_run.assert_called_with(job_template_infile=mock_file.return_value, token=None)
+
+    def test_job_run_with_token(self):
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.arg_parser.parse_and_run_commands(["job", "run", "job_template.yaml", "--token", "secret"])
+        self.target_object.job_run.assert_called_with(job_template_infile=mock_file.return_value, token="secret")
+
+    def test_job_validate(self):
+        with patch("builtins.open", mock_open(read_data="data")) as mock_file:
+            self.arg_parser.parse_and_run_commands(["job", "validate", "job_template.yaml"])
+        self.target_object.job_validate.assert_called_with(job_template_infile=mock_file.return_value)
 
     def test_start_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "start", "123"])
-        self.target_object.start_job.assert_called_with(123, None)
+        self.arg_parser.parse_and_run_commands(["job", "start", "123"])
+        self.target_object.start_job.assert_called_with(job_id=123, token=None)
 
     def test_start_job_with_optional_token(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "start", "123", "--token", "secret"])
-        self.target_object.start_job.assert_called_with(123, "secret")
+        self.arg_parser.parse_and_run_commands(["job", "start", "123", "--token", "secret"])
+        self.target_object.start_job.assert_called_with(job_id=123, token="secret")
 
     def test_cancel_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "cancel", "123"])
-        self.target_object.cancel_job.assert_called_with(123)
+        self.arg_parser.parse_and_run_commands(["job", "cancel", "123"])
+        self.target_object.cancel_job.assert_called_with(job_id=123)
 
     def test_restart_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "restart", "123"])
-        self.target_object.restart_job.assert_called_with(123)
+        self.arg_parser.parse_and_run_commands(["job", "restart", "123"])
+        self.target_object.restart_job.assert_called_with(job_id=123)
 
     def test_delete_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "delete", "123"])
-        self.target_object.delete_job.assert_called_with(123)
+        self.arg_parser.parse_and_run_commands(["job", "delete", "123"])
+        self.target_object.delete_job.assert_called_with(job_id=123)

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -23,8 +23,8 @@ class ArgParserTestCase(TestCase):
         self.target_object.workflows_list.assert_called_with(all_versions=True)
 
     def test_workflow_configuration_show_joborder(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "configurations", "joborder", "--tag", "exome/v1/human"])
-        self.target_object.workflow_configuration_job_order_show.assert_called_with("exome/v1/human", sys.stdout)
+        self.arg_parser.parse_and_run_commands(["workflows", "configurations", "job-order", "3"])
+        self.target_object.workflow_configuration_job_order_show.assert_called_with(3, sys.stdout)
 
     def test_init_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "init", "exome/v1/human"])

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -27,7 +27,7 @@ class ArgParserTestCase(TestCase):
         self.target_object.workflow_configuration_show.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_init_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "init", "--tag", "exome/v1/human"])
+        self.arg_parser.parse_and_run_commands(["jobs", "init", "exome/v1/human"])
         self.target_object.init_job.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_create_job(self):

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -22,9 +22,9 @@ class ArgParserTestCase(TestCase):
         self.arg_parser.parse_and_run_commands(["workflows", "list", "-a"])
         self.target_object.workflows_list.assert_called_with(all_versions=True)
 
-    def test_workflow_configuration_show(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "configuration", "--tag", "exome/v1/human"])
-        self.target_object.workflow_configuration_show.assert_called_with("exome/v1/human", sys.stdout)
+    def test_workflow_configuration_show_joborder(self):
+        self.arg_parser.parse_and_run_commands(["workflows", "joborder", "--tag", "exome/v1/human"])
+        self.target_object.workflow_configuration_job_order_show.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_init_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "init", "exome/v1/human"])

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -31,12 +31,16 @@ class ArgParserTestCase(TestCase):
         self.target_object.init_job.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_create_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py"])
-        self.target_object.create_job.assert_called_with(ANY, False)
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--share-group", "1"])
+        self.target_object.create_job.assert_called_with(ANY, False, '1', None)
 
     def test_create_job_dry_run(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run"])
-        self.target_object.create_job.assert_called_with(ANY, True)
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run", "--share-group", "2"])
+        self.target_object.create_job.assert_called_with(ANY, True,  '2', None)
+
+    def test_create_job_with_vm_strategy(self):
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--share-group", "1", "--vm-strategy", "2"])
+        self.target_object.create_job.assert_called_with(ANY, False,  '1', '2')
 
     def test_start_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "start", "123"])

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -23,7 +23,7 @@ class ArgParserTestCase(TestCase):
         self.target_object.workflows_list.assert_called_with(all_versions=True)
 
     def test_workflow_configuration_show_joborder(self):
-        self.arg_parser.parse_and_run_commands(["workflows", "joborder", "--tag", "exome/v1/human"])
+        self.arg_parser.parse_and_run_commands(["workflows", "configurations", "joborder", "--tag", "exome/v1/human"])
         self.target_object.workflow_configuration_job_order_show.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_init_job(self):

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -31,16 +31,16 @@ class ArgParserTestCase(TestCase):
         self.target_object.init_job.assert_called_with("exome/v1/human", sys.stdout)
 
     def test_create_job(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--share-group", "1"])
-        self.target_object.create_job.assert_called_with(ANY, False, '1', None)
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py"])
+        self.target_object.create_job.assert_called_with(ANY, False, None)
 
     def test_create_job_dry_run(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run", "--share-group", "2"])
-        self.target_object.create_job.assert_called_with(ANY, True,  '2', None)
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--dry-run"])
+        self.target_object.create_job.assert_called_with(ANY, True, None)
 
     def test_create_job_with_vm_strategy(self):
-        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--share-group", "1", "--vm-strategy", "2"])
-        self.target_object.create_job.assert_called_with(ANY, False,  '1', '2')
+        self.arg_parser.parse_and_run_commands(["jobs", "create", "setup.py", "--vm-strategy", "2"])
+        self.target_object.create_job.assert_called_with(ANY, False, '2')
 
     def test_start_job(self):
         self.arg_parser.parse_and_run_commands(["jobs", "start", "123"])

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -214,7 +214,7 @@ class TableTestCase(TestCase):
 class WorkflowDetailsTestCase(TestCase):
     def test_get_column_data(self):
         def make_tag(num):
-            return {'tag': 'v{}'.format(num)}
+            return {'tag': 'exome/v{}'.format(num)}
 
         mock_api = Mock()
         mock_api.workflows_list.return_value = [

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -192,15 +192,13 @@ class CommandsTestCase(TestCase):
     @patch('bespin.commands.print')
     def test_workflow_configuration_job_order_show(self, mock_print, mock_bespin_api, mock_config_file):
         mock_outfile = Mock()
-        mock_bespin_api.return_value.workflow_configurations_list.return_value = [
-            {
-                "system_job_order": {
-                    "threads": 2
-                }
+        mock_bespin_api.return_value.workflow_configurations_get.return_value = {
+            "system_job_order": {
+                "threads": 2
             }
-        ]
+        }
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.workflow_configuration_job_order_show(tag='mytag', outfile=mock_outfile)
+        commands.workflow_configuration_job_order_show(workflow_configuration_id=2, outfile=mock_outfile)
         mock_outfile.write.assert_called_with('threads: 2\n')
 
 

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from bespin.commands import Commands, Table, WorkflowDetails, JobFile, JobFileLoader, JobConfiguration, \
-    STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, FILE_PLACEHOLDER, IncompleteJobFileException, \
-    JobOrderWalker, JobOrderPlaceholderCheck, JobOrderFormatFiles, JobOrderFileDetails, JobsList
+from bespin.commands import Commands, Table, WorkflowDetails, JobsList
 from mock import patch, call, Mock
-import yaml
-import json
 
 
 class CommandsTestCase(TestCase):
@@ -58,68 +54,68 @@ class CommandsTestCase(TestCase):
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
-    @patch('bespin.commands.JobConfiguration')
+    @patch('bespin.jobtemplate.JobConfiguration')
     @patch('bespin.commands.print')
     def test_init_job(self, mock_print, mock_job_configuration, mock_bespin_api, mock_config_file):
         mock_outfile = Mock()
-        mock_bespin_api.return_value.init_job_file.return_value = {}
+        mock_bespin_api.return_value.job_templates_init.return_value = {}
 
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.init_job(tag='rnaseq/v1/human', outfile=mock_outfile)
+        commands.job_template_init(tag='rnaseq/v1/human', outfile=mock_outfile)
 
-        mock_bespin_api.return_value.init_job_file.assert_called_with('rnaseq/v1/human')
+        mock_bespin_api.return_value.job_templates_init.assert_called_with('rnaseq/v1/human')
         mock_outfile.write.assert_called_with('{}\n')
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
-    @patch('bespin.commands.JobFileLoader')
+    @patch('bespin.commands.JobTemplateLoader')
     @patch('bespin.commands.print')
-    def test_create_job(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
+    def test_create_job(self, mock_print, mock_job_template_loader, mock_bespin_api, mock_config_file):
         mock_infile = Mock()
-        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'job': 1}
+        mock_job_template_loader.return_value.create_job_template.return_value.create_job.return_value = {'job': 1}
 
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.create_job(infile=mock_infile, dry_run=False, share_group=1)
+        commands.create_job(infile=mock_infile, dry_run=False)
 
-        mock_job_file_loader.assert_called_with(mock_infile)
+        mock_job_template_loader.assert_called_with(mock_infile)
         mock_print.assert_has_calls([
             call("Created job 1"),
             call("To start this job run `bespin jobs start 1` .")])
-        mock_job_file = mock_job_file_loader.return_value.create_job_file.return_value
-        mock_job_file.create_job.assert_called_with(mock_bespin_api.return_value)
+        mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
+        mock_job_template.create_job.assert_called_with(mock_bespin_api.return_value)
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
-    @patch('bespin.commands.JobFileLoader')
+    @patch('bespin.commands.JobTemplateLoader')
     @patch('bespin.commands.print')
-    def test_create_job_dry_run(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
+    def test_create_job_dry_run(self, mock_print, mock_job_template_loader, mock_bespin_api, mock_config_file):
         mock_infile = Mock()
 
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.create_job(infile=mock_infile, dry_run=True, share_group=1)
+        commands.create_job(infile=mock_infile, dry_run=True)
 
-        mock_job_file_loader.assert_called_with(mock_infile)
-        mock_job_file = mock_job_file_loader.return_value.create_job_file.return_value
-        mock_job_file.verify_job.assert_called_with(mock_bespin_api.return_value)
+        mock_job_template_loader.assert_called_with(mock_infile)
+        mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
+        mock_job_template.verify_job.assert_called_with(mock_bespin_api.return_value)
         mock_print.assert_called_with('Job file is valid.')
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
-    @patch('bespin.commands.JobFileLoader')
+    @patch('bespin.commands.JobTemplateLoader')
     @patch('bespin.commands.print')
-    def test_create_job_with_vm_strategy(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
+    def test_create_job_with_vm_strategy(self, mock_print, mock_job_template_loader, mock_bespin_api, mock_config_file):
         mock_infile = Mock()
-        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'job': 1}
+        mock_job_template_loader.return_value.create_job_template.return_value.create_job.return_value = {'job': 1}
 
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.create_job(infile=mock_infile, dry_run=False, share_group=1, vm_strategy=2)
+        commands.create_job(infile=mock_infile, dry_run=False, vm_strategy=2)
 
-        mock_job_file_loader.assert_called_with(mock_infile)
+        mock_job_template_loader.assert_called_with(mock_infile)
         mock_print.assert_has_calls([
             call("Created job 1"),
             call("To start this job run `bespin jobs start 1` .")])
-        mock_job_file = mock_job_file_loader.return_value.create_job_file.return_value
-        mock_job_file.create_job.assert_called_with(mock_bespin_api.return_value)
+        mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
+        mock_job_template.create_job.assert_called_with(mock_bespin_api.return_value)
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
@@ -286,534 +282,6 @@ class WorkflowDetailsTestCase(TestCase):
         column_data = details.get_column_data()
         self.assertEqual(len(column_data), 0)
         mock_api.questionnaires_list.assert_not_called()
-
-
-class JobFileTestCase(TestCase):
-    def test_to_dict(self):
-        job_file = JobFile(workflow_tag='sometag', name='myjob', fund_code='001', job_order={})
-        expected_dict = {
-            'fund_code': '001',
-            'job_order': {},
-            'name': 'myjob',
-            'workflow_tag': 'sometag'
-        }
-        self.assertEqual(job_file.to_dict(), expected_dict)
-
-    def test_create_user_job_order_json(self):
-        job_file = JobFile(workflow_tag='sometag', name='myjob', fund_code='001', job_order={
-            'myfile': {
-                'class': 'File',
-                'path': 'dds://project/somepath.txt'
-            },
-            'my_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'my_url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-            'myint': 123,
-            'myfileary': [
-                {
-                    'class': 'File',
-                    'path': 'dds://project/somepath1.txt'
-                },
-                {
-                    'class': 'File',
-                    'path': 'dds://project/somepath2.txt'
-                },
-            ],
-            'myfastq_pairs': [
-                {'file1':
-                     {'class': 'File',
-                      'path': 'dds://myproject/rawData/SAAAA_R1_001.fastq.gz'
-                      },
-                 'file2': {
-                     'class': 'File',
-                     'path': 'dds://myproject/rawData/SAAAA_R2_001.fastq.gz'
-                 },
-                 'name': 'Sample1'}]
-        })
-        user_job_order = job_file.create_user_job_order()
-        self.assertEqual(user_job_order['myint'], 123)
-        self.assertEqual(user_job_order['myfile'], {
-            'class': 'File',
-            'path': 'dds_project_somepath.txt'
-        })
-        self.assertEqual(user_job_order['myfileary'], [
-            {
-                'class': 'File',
-                'path': 'dds_project_somepath1.txt'
-            },
-            {
-                'class': 'File',
-                'path': 'dds_project_somepath2.txt'
-            },
-        ])
-        self.assertEqual(user_job_order['myfastq_pairs'], [
-            {'file1':
-                 {'class': 'File',
-                  'path': 'dds_myproject_rawData_SAAAA_R1_001.fastq.gz'
-                  },
-             'file2': {
-                 'class': 'File',
-                 'path': 'dds_myproject_rawData_SAAAA_R2_001.fastq.gz'
-             },
-             'name': 'Sample1'}])
-        self.assertEqual(user_job_order['my_path_file'], {
-            'class': 'File',
-            'path': '/tmp/data.txt'
-        }, "Plain file paths should not be modified.")
-        self.assertEqual(user_job_order['my_url_file'], {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-        }, "URL file paths should not be modified.")
-
-    @patch('bespin.commands.DDSFileUtil')
-    def test_get_dds_files_details(self, mock_dds_file_util):
-        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
-        job_file = JobFile(workflow_tag='sometag', name='myjob', fund_code='001', job_order={
-            'myfile': {
-                'class': 'File',
-                'path': 'dds://project_somepath.txt'
-            },
-            'myint': 123
-        })
-        file_details = job_file.get_dds_files_details()
-        self.assertEqual(file_details, [('filedata1', 'dds_project_somepath.txt')])
-
-    @patch('bespin.commands.DDSFileUtil')
-    def test_create_job(self, mock_dds_file_util):
-        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
-        mock_api = Mock()
-        mock_api.dds_user_credentials_list.return_value = [{'id': 111, 'dds_id': 112}]
-        mock_api.workflow_configurations_list.return_value = [
-            {
-                'id': 222
-            }
-        ]
-        mock_api.stage_group_post.return_value = {
-            'id': 333
-        }
-        job_file = JobFile(workflow_tag='sometag', name='myjob', fund_code='001', job_order={
-            'myfile': {
-                'class': 'File',
-                'path': 'dds://project_somepath.txt'
-            },
-            'myint': 555
-        })
-        job_file.get_dds_files_details = Mock()
-        mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
-        mock_file.id = 777
-        job_file.get_dds_files_details.return_value = [[mock_file, 'somepath']]
-
-        job_file.create_job(mock_api)
-
-        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
-        mock_api.dds_job_input_files_post.assert_called_with(666, 777, 'somepath', 0, 0, 111, stage_group_id=333,
-                                                             size=4002)
-        mock_api.create_job.assert_called_with({
-            'name': 'myjob',
-            'fund_code': '001',
-            'job_order': {
-                'myfile': {
-                    'class': 'File',
-                    'path': 'dds_project_somepath.txt'
-                },
-                'myint': 555
-            },
-            'workflow_tag': 'sometag',
-            'stage_group': 333
-        })
-        mock_dds_file_util.return_value.give_download_permissions.assert_called_with(666, 112)
-
-    @patch('bespin.commands.DDSFileUtil')
-    @patch('bespin.commands.JobOrderFormatFiles')
-    def test_verify_job(self, mock_job_order_format_files, mock_dds_file_util):
-        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
-        mock_api = Mock()
-        mock_api.dds_user_credentials_list.return_value = [{'id': 111, 'dds_id': 112}]
-        mock_api.workflow_configurations_list.return_value = [
-            {
-                'id': 222
-            }
-        ]
-        mock_api.stage_group_post.return_value = {
-            'id': 333
-        }
-        job_order = {
-            'myfile': {
-                'class': 'File',
-                'path': 'dds://project_somepath.txt'
-            },
-            'myint': 555
-        }
-        job_file = JobFile(workflow_tag='sometag', name='myjob', fund_code='001', job_order=job_order)
-        job_file.get_dds_files_details = Mock()
-        mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
-        mock_file.id = 777
-        job_file.get_dds_files_details.return_value = [[mock_file, 'somepath']]
-
-        job_file.verify_job(mock_api)
-        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
-        job_file.get_dds_files_details.assert_called_with()
-        mock_job_order_format_files.return_value.walk.assert_called_with(job_order)
-
-
-class JobFileLoaderTestCase(TestCase):
-    @patch('bespin.commands.yaml')
-    def test_create_job_file(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': 'myjob',
-            'fund_code': '0001',
-            'job_order': {},
-            'workflow_tag': 'mytag',
-        }
-        job_file_loader = JobFileLoader(Mock())
-        job_file_loader.validate_job_file_data = Mock()
-        job_file = job_file_loader.create_job_file(share_group_id=1, vm_strategy_id=2)
-
-        self.assertEqual(job_file.name, 'myjob')
-        self.assertEqual(job_file.fund_code, '0001')
-        self.assertEqual(job_file.job_order, {})
-        self.assertEqual(job_file.workflow_tag, 'mytag')
-        self.assertEqual(job_file.share_group_id, 1)
-        self.assertEqual(job_file.job_vm_strategy_id, 2)
-
-    @patch('bespin.commands.yaml')
-    def test_validate_job_file_data_ok(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': 'myjob',
-            'fund_code': '0001',
-            'job_order': {},
-            'workflow_tag': 'mytag',
-        }
-        job_file_loader = JobFileLoader(Mock())
-        job_file_loader.validate_job_file_data()
-
-    @patch('bespin.commands.yaml')
-    def test_validate_job_file_data_invalid_name_and_fund_code(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': STRING_VALUE_PLACEHOLDER,
-            'fund_code': STRING_VALUE_PLACEHOLDER,
-            'job_order': {},
-            'workflow_tag': 'mytag',
-        }
-        job_file_loader = JobFileLoader(Mock())
-        with self.assertRaises(IncompleteJobFileException) as raised_exception:
-            job_file_loader.validate_job_file_data()
-        self.assertEqual(str(raised_exception.exception),
-                         'Please fill in placeholder values for field(s): fund_code, name')
-
-    @patch('bespin.commands.yaml')
-    def test_validate_job_file_data_invalid_job_order_params(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': 'myjob',
-            'fund_code': '0001',
-            'job_order': {
-                'intval': INT_VALUE_PLACEHOLDER,
-                'fileval': {
-                    'class': 'File',
-                    'path': FILE_PLACEHOLDER
-                },
-                'otherint': 123,
-                'otherfile': {
-                    'class': 'File',
-                    'path': 'somefile.txt'
-                },
-            },
-            'workflow_tag': 'mytag',
-        }
-        job_file_loader = JobFileLoader(Mock())
-        with self.assertRaises(IncompleteJobFileException) as raised_exception:
-            job_file_loader.validate_job_file_data()
-        self.assertEqual(str(raised_exception.exception),
-                         'Please fill in placeholder values for field(s): job_order.fileval, job_order.intval')
-
-
-class JobConfigurationTestCase(TestCase):
-    def test_create_job_file_with_placeholders(self):
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': {}
-        })
-        job_file = configuration.create_job_file_with_placeholders()
-        self.assertEqual(job_file.workflow_tag, 'mytag')
-        self.assertEqual(job_file.name, STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(job_file.fund_code, STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(job_file.job_order, {})
-
-    def test_format_user_fields(self):
-        user_fields = [
-            {"type": "int", "name": "myint"},
-            {"type": "string", "name": "mystr"},
-            {"type": {"type": "array",  "items": "int"}, "name": "intary"}
-        ]
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': user_fields,
-        })
-        user_fields = configuration.format_user_fields()
-        self.assertEqual(user_fields, {
-            'intary': [INT_VALUE_PLACEHOLDER], 'myint': INT_VALUE_PLACEHOLDER, 'mystr': STRING_VALUE_PLACEHOLDER
-        })
-
-    def test_create_placeholder_value(self):
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': {}
-        })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='string', is_array=False),
-            STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='int', is_array=False),
-            INT_VALUE_PLACEHOLDER)
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='int', is_array=True),
-            [INT_VALUE_PLACEHOLDER])
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='File', is_array=False),
-            {
-                "class": "File",
-                "path": FILE_PLACEHOLDER
-            })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='File', is_array=True),
-            [{
-                "class": "File",
-                "path": FILE_PLACEHOLDER
-            }])
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=False),
-            {
-                "name": STRING_VALUE_PLACEHOLDER,
-                "file1": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                },
-                "file2": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                }
-            })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=True),
-            [{
-                "name": STRING_VALUE_PLACEHOLDER,
-                "file1": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                },
-                "file2": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                }
-            }])
-
-
-class JobOrderWalkerTestCase(TestCase):
-    def test_walk(self):
-        walker = JobOrderWalker()
-        walker.on_class_value = Mock()
-        walker.on_simple_value = Mock()
-        walker.walk({
-            'color': 'red',
-            'weight': 123,
-            'file1': {
-                'class': 'File',
-                'path': 'somepath'
-            },
-            'file_ary': [
-                {
-                    'class': 'File',
-                    'path': 'somepath1'
-                }, {
-                    'class': 'File',
-                    'path': 'somepath2'
-                },
-            ],
-            'nested': {
-                'a': [{
-                    'class': 'File',
-                    'path': 'somepath3'
-                }]
-            },
-            'plain_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-        })
-
-        walker.on_simple_value.assert_has_calls([
-            call('color', 'red'),
-            call('weight', 123),
-        ])
-        walker.on_class_value.assert_has_calls([
-            call('file1', {'class': 'File', 'path': 'somepath'}),
-            call('file_ary', {'class': 'File', 'path': 'somepath1'}),
-            call('file_ary', {'class': 'File', 'path': 'somepath2'}),
-            call('nested', {'class': 'File', 'path': 'somepath3'}),
-        ])
-
-    def test_format_file_path(self):
-        data = [
-            # input    expected
-            ('https://placeholder.data/stuff/data.txt', 'https://placeholder.data/stuff/data.txt'),
-            ('dds://myproject/rawData/SAAAA_R1_001.fastq.gz', 'dds_myproject_rawData_SAAAA_R1_001.fastq.gz'),
-            ('dds://project/somepath.txt', 'dds_project_somepath.txt'),
-            ('dds://project/dir/somepath.txt', 'dds_project_dir_somepath.txt'),
-        ]
-        for input_val, expected_val in data:
-            self.assertEqual(JobOrderWalker.format_file_path(input_val), expected_val)
-
-
-class JobOrderPlaceholderCheckTestCase(TestCase):
-    def test_walk(self):
-        job_order = {
-            'good_str': 'a',
-            'bad_str': STRING_VALUE_PLACEHOLDER,
-            'good_int': 123,
-            'bad_int': INT_VALUE_PLACEHOLDER,
-            'good_file': {
-                'class': 'File',
-                'path': 'somepath.txt',
-            },
-            'bad_file': {
-                'class': 'File',
-                'path': FILE_PLACEHOLDER,
-            },
-            'good_str_ary': ['a', 'b', 'c'],
-            'bad_str_ary': ['a', STRING_VALUE_PLACEHOLDER, 'c'],
-            'good_file_ary': [{
-                'class': 'File',
-                'path': 'somepath.txt',
-            }],
-            'bad_file_ary': [{
-                'class': 'File',
-                'path': FILE_PLACEHOLDER,
-            }],
-            'good_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': 'somepath.txt',
-                }
-            },
-            'bad_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': FILE_PLACEHOLDER,
-                }
-            },
-            'plain_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-        }
-        expected_keys = [
-            'bad_str', 'bad_int', 'bad_file', 'bad_str_ary', 'bad_file_ary', 'bad_file_dict',
-        ]
-
-        checker = JobOrderPlaceholderCheck()
-        checker.walk(job_order)
-
-        self.assertEqual(checker.keys_with_placeholders, set(expected_keys))
-
-
-class JobOrderFormatFilesTestCase(TestCase):
-    def test_walk(self):
-        job_order = {
-            'good_str': 'a',
-            'good_int': 123,
-            'good_file': {
-                'class': 'File',
-                'path': 'dds://project1/data/somepath.txt',
-            },
-            'good_str_ary': ['a', 'b', 'c'],
-            'good_file_ary': [{
-                'class': 'File',
-                'path': 'dds://project2/data/somepath2.txt',
-            }],
-            'good_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': 'dds://project3/data/other/somepath.txt',
-                }
-            },
-            'plain_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-        }
-
-        formatter = JobOrderFormatFiles()
-        formatter.walk(job_order)
-
-        self.assertEqual(job_order['good_str'], 'a')
-        self.assertEqual(job_order['good_int'], 123)
-        self.assertEqual(job_order['good_file'],
-                         {'class': 'File', 'path': 'dds_project1_data_somepath.txt'})
-        self.assertEqual(job_order['good_str_ary'], ['a', 'b', 'c'])
-        self.assertEqual(job_order['good_file_ary'],
-                         [{'class': 'File', 'path': 'dds_project2_data_somepath2.txt'}])
-        self.assertEqual(job_order['good_file_dict'],
-                         {'stuff': {'class': 'File', 'path': 'dds_project3_data_other_somepath.txt'}})
-
-
-class JobOrderFileDetailsTestCase(TestCase):
-    @patch('bespin.commands.DDSFileUtil')
-    def test_walk(self, mock_dds_file_util):
-        mock_dds_file_util.return_value.find_file_for_path.return_value = 'ddsfiledata'
-        job_order = {
-            'good_str': 'a',
-            'good_int': 123,
-            'good_file': {
-                'class': 'File',
-                'path': 'dds://project1/data/somepath.txt',
-            },
-            'good_str_ary': ['a', 'b', 'c'],
-            'good_file_ary': [{
-                'class': 'File',
-                'path': 'dds://project2/data/somepath2.txt',
-            }],
-            'good_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': 'dds://project3/data/other/somepath.txt',
-                }
-            },
-            'plain_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-        }
-        expected_dds_file_info = [
-            ('ddsfiledata', 'dds_project1_data_somepath.txt'),
-            ('ddsfiledata', 'dds_project2_data_somepath2.txt'),
-            ('ddsfiledata', 'dds_project3_data_other_somepath.txt')
-        ]
-
-        details = JobOrderFileDetails()
-        details.walk(job_order)
-
-        self.assertEqual(details.dds_files, expected_dds_file_info)
 
 
 class JobsListTestCase(TestCase):

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -76,7 +76,7 @@ class CommandsTestCase(TestCase):
     @patch('bespin.commands.print')
     def test_create_job(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
         mock_infile = Mock()
-        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'id': 1}
+        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'job': 1}
 
         commands = Commands(self.version_str, self.user_agent_str)
         commands.create_job(infile=mock_infile, dry_run=False, share_group=1)
@@ -109,7 +109,7 @@ class CommandsTestCase(TestCase):
     @patch('bespin.commands.print')
     def test_create_job_with_vm_strategy(self, mock_print, mock_job_file_loader, mock_bespin_api, mock_config_file):
         mock_infile = Mock()
-        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'id': 1}
+        mock_job_file_loader.return_value.create_job_file.return_value.create_job.return_value = {'job': 1}
 
         commands = Commands(self.version_str, self.user_agent_str)
         commands.create_job(infile=mock_infile, dry_run=False, share_group=1, vm_strategy=2)
@@ -190,14 +190,18 @@ class CommandsTestCase(TestCase):
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
     @patch('bespin.commands.print')
-    def test_workflow_configuration_show(self, mock_print, mock_bespin_api, mock_config_file):
+    def test_workflow_configuration_job_order_show(self, mock_print, mock_bespin_api, mock_config_file):
         mock_outfile = Mock()
         mock_bespin_api.return_value.workflow_configurations_list.return_value = [
-            {}
+            {
+                "system_job_order": {
+                    "threads": 2
+                }
+            }
         ]
         commands = Commands(self.version_str, self.user_agent_str)
-        commands.workflow_configuration_show(tag='mytag', outfile=mock_outfile)
-        mock_outfile.write.assert_called_with('{}\n')
+        commands.workflow_configuration_job_order_show(tag='mytag', outfile=mock_outfile)
+        mock_outfile.write.assert_called_with('threads: 2\n')
 
 
 class TableTestCase(TestCase):

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -81,7 +81,7 @@ class CommandsTestCase(TestCase):
         mock_job_template_loader.assert_called_with(mock_infile)
         mock_print.assert_has_calls([
             call("Created job 1"),
-            call("To start this job run `bespin jobs start 1` .")])
+            call("To start this job run `bespin job start 1` .")])
         mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
         mock_job_template.create_job.assert_called_with(mock_bespin_api.return_value)
 

--- a/bespin/test_jobtemplate.py
+++ b/bespin/test_jobtemplate.py
@@ -116,7 +116,7 @@ class JobTemplateTestCase(TestCase):
         mock_api.stage_group_post.return_value = {
             'id': 333
         }
-        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
+        job_template = JobTemplate(tag='sometag/v1/human', name='myjob', fund_code='001', job_order={
             'myfile': {
                 'class': 'File',
                 'path': 'dds://project_somepath.txt'
@@ -130,7 +130,7 @@ class JobTemplateTestCase(TestCase):
 
         job_template.create_job(mock_api)
 
-        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
+        mock_api.workflow_configurations_list.assert_called_with(tag='human', workflow_tag='sometag')
         mock_api.dds_job_input_files_post.assert_called_with(666, 777, 'somepath', 0, 0, 111, stage_group_id=333,
                                                              size=4002)
         mock_api.job_templates_create_job.assert_called_with({
@@ -143,7 +143,7 @@ class JobTemplateTestCase(TestCase):
                 },
                 'myint': 555
             },
-            'tag': 'sometag',
+            'tag': 'sometag/v1/human',
             'stage_group': 333
         })
         mock_dds_file_util.return_value.give_download_permissions.assert_called_with(666, 112)
@@ -169,14 +169,14 @@ class JobTemplateTestCase(TestCase):
             },
             'myint': 555
         }
-        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order=job_order)
+        job_template = JobTemplate(tag='sometag/v1/human', name='myjob', fund_code='001', job_order=job_order)
         job_template.get_dds_files_details = Mock()
         mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
         mock_file.id = 777
         job_template.get_dds_files_details.return_value = [[mock_file, 'somepath']]
 
         job_template.verify_job(mock_api)
-        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
+        mock_api.workflow_configurations_list.assert_called_with(tag='human', workflow_tag='sometag')
         job_template.get_dds_files_details.assert_called_with()
         mock_job_order_format_files.return_value.walk.assert_called_with(job_order)
 
@@ -192,13 +192,12 @@ class JobFileLoaderTestCase(TestCase):
         }
         job_template_loader = JobTemplateLoader(Mock())
         job_template_loader.validate_job_file_data = Mock()
-        job_template = job_template_loader.create_job_template(vm_strategy_id=2)
+        job_template = job_template_loader.create_job_template()
 
         self.assertEqual(job_template.name, 'myjob')
         self.assertEqual(job_template.fund_code, '0001')
         self.assertEqual(job_template.job_order, {})
         self.assertEqual(job_template.tag, 'mytag')
-        self.assertEqual(job_template.job_vm_strategy_id, 2)
 
     @patch('bespin.jobtemplate.yaml')
     def test_validate_job_file_data_ok(self, mock_yaml):

--- a/bespin/test_jobtemplate.py
+++ b/bespin/test_jobtemplate.py
@@ -1,0 +1,536 @@
+from __future__ import absolute_import
+from unittest import TestCase
+import yaml
+import json
+from bespin.jobtemplate import JobTemplate, JobTemplateLoader, JobConfiguration, JobOrderWalker, JobOrderFileDetails, \
+    JobOrderFormatFiles, JobOrderPlaceholderCheck, STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, FILE_PLACEHOLDER
+from bespin.exceptions import IncompleteJobTemplateException
+from mock import patch, call, Mock
+
+
+class JobTemplateTestCase(TestCase):
+    def test_to_dict(self):
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={})
+        expected_dict = {
+            'fund_code': '001',
+            'job_order': {},
+            'name': 'myjob',
+            'tag': 'sometag'
+        }
+        self.assertEqual(job_template.to_dict(), expected_dict)
+
+    def test_create_user_job_order_json(self):
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project/somepath.txt'
+            },
+            'my_path_file': {
+                'class': 'File',
+                'path': '/tmp/data.txt'
+            },
+            'my_url_file': {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+            },
+            'myint': 123,
+            'myfileary': [
+                {
+                    'class': 'File',
+                    'path': 'dds://project/somepath1.txt'
+                },
+                {
+                    'class': 'File',
+                    'path': 'dds://project/somepath2.txt'
+                },
+            ],
+            'myfastq_pairs': [
+                {'file1':
+                     {'class': 'File',
+                      'path': 'dds://myproject/rawData/SAAAA_R1_001.fastq.gz'
+                      },
+                 'file2': {
+                     'class': 'File',
+                     'path': 'dds://myproject/rawData/SAAAA_R2_001.fastq.gz'
+                 },
+                 'name': 'Sample1'}]
+        })
+        user_job_order = job_template.create_user_job_order()
+        self.assertEqual(user_job_order['myint'], 123)
+        self.assertEqual(user_job_order['myfile'], {
+            'class': 'File',
+            'path': 'dds_project_somepath.txt'
+        })
+        self.assertEqual(user_job_order['myfileary'], [
+            {
+                'class': 'File',
+                'path': 'dds_project_somepath1.txt'
+            },
+            {
+                'class': 'File',
+                'path': 'dds_project_somepath2.txt'
+            },
+        ])
+        self.assertEqual(user_job_order['myfastq_pairs'], [
+            {'file1':
+                 {'class': 'File',
+                  'path': 'dds_myproject_rawData_SAAAA_R1_001.fastq.gz'
+                  },
+             'file2': {
+                 'class': 'File',
+                 'path': 'dds_myproject_rawData_SAAAA_R2_001.fastq.gz'
+             },
+             'name': 'Sample1'}])
+        self.assertEqual(user_job_order['my_path_file'], {
+            'class': 'File',
+            'path': '/tmp/data.txt'
+        }, "Plain file paths should not be modified.")
+        self.assertEqual(user_job_order['my_url_file'], {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+        }, "URL file paths should not be modified.")
+
+    @patch('bespin.jobtemplate.DDSFileUtil')
+    def test_get_dds_files_details(self, mock_dds_file_util):
+        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project_somepath.txt'
+            },
+            'myint': 123
+        })
+        file_details = job_template.get_dds_files_details()
+        self.assertEqual(file_details, [('filedata1', 'dds_project_somepath.txt')])
+
+    @patch('bespin.jobtemplate.DDSFileUtil')
+    def test_create_job(self, mock_dds_file_util):
+        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
+        mock_api = Mock()
+        mock_api.dds_user_credentials_list.return_value = [{'id': 111, 'dds_id': 112}]
+        mock_api.workflow_configurations_list.return_value = [
+            {
+                'id': 222
+            }
+        ]
+        mock_api.stage_group_post.return_value = {
+            'id': 333
+        }
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project_somepath.txt'
+            },
+            'myint': 555
+        })
+        job_template.get_dds_files_details = Mock()
+        mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
+        mock_file.id = 777
+        job_template.get_dds_files_details.return_value = [[mock_file, 'somepath']]
+
+        job_template.create_job(mock_api)
+
+        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
+        mock_api.dds_job_input_files_post.assert_called_with(666, 777, 'somepath', 0, 0, 111, stage_group_id=333,
+                                                             size=4002)
+        mock_api.job_templates_create_job.assert_called_with({
+            'name': 'myjob',
+            'fund_code': '001',
+            'job_order': {
+                'myfile': {
+                    'class': 'File',
+                    'path': 'dds_project_somepath.txt'
+                },
+                'myint': 555
+            },
+            'tag': 'sometag',
+            'stage_group': 333
+        })
+        mock_dds_file_util.return_value.give_download_permissions.assert_called_with(666, 112)
+
+    @patch('bespin.jobtemplate.DDSFileUtil')
+    @patch('bespin.jobtemplate.JobOrderFormatFiles')
+    def test_verify_job(self, mock_job_order_format_files, mock_dds_file_util):
+        mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
+        mock_api = Mock()
+        mock_api.dds_user_credentials_list.return_value = [{'id': 111, 'dds_id': 112}]
+        mock_api.workflow_configurations_list.return_value = [
+            {
+                'id': 222
+            }
+        ]
+        mock_api.stage_group_post.return_value = {
+            'id': 333
+        }
+        job_order = {
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project_somepath.txt'
+            },
+            'myint': 555
+        }
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order=job_order)
+        job_template.get_dds_files_details = Mock()
+        mock_file = Mock(project_id=666, current_version={'upload': {'size': 4002}})
+        mock_file.id = 777
+        job_template.get_dds_files_details.return_value = [[mock_file, 'somepath']]
+
+        job_template.verify_job(mock_api)
+        mock_api.workflow_configurations_list.assert_called_with(tag='sometag')
+        job_template.get_dds_files_details.assert_called_with()
+        mock_job_order_format_files.return_value.walk.assert_called_with(job_order)
+
+
+class JobFileLoaderTestCase(TestCase):
+    @patch('bespin.jobtemplate.yaml')
+    def test_create_job_file(self, mock_yaml):
+        mock_yaml.load.return_value = {
+            'name': 'myjob',
+            'fund_code': '0001',
+            'job_order': {},
+            'tag': 'mytag',
+        }
+        job_template_loader = JobTemplateLoader(Mock())
+        job_template_loader.validate_job_file_data = Mock()
+        job_template = job_template_loader.create_job_template(vm_strategy_id=2)
+
+        self.assertEqual(job_template.name, 'myjob')
+        self.assertEqual(job_template.fund_code, '0001')
+        self.assertEqual(job_template.job_order, {})
+        self.assertEqual(job_template.tag, 'mytag')
+        self.assertEqual(job_template.job_vm_strategy_id, 2)
+
+    @patch('bespin.jobtemplate.yaml')
+    def test_validate_job_file_data_ok(self, mock_yaml):
+        mock_yaml.load.return_value = {
+            'name': 'myjob',
+            'fund_code': '0001',
+            'job_order': {},
+            'tag': 'mytag',
+        }
+        job_template_loader = JobTemplateLoader(Mock())
+        job_template_loader.validate_job_file_data()
+
+    @patch('bespin.jobtemplate.yaml')
+    def test_validate_job_file_data_invalid_name_and_fund_code(self, mock_yaml):
+        mock_yaml.load.return_value = {
+            'name': STRING_VALUE_PLACEHOLDER,
+            'fund_code': STRING_VALUE_PLACEHOLDER,
+            'job_order': {},
+            'tag': 'mytag',
+        }
+        job_template_loader = JobTemplateLoader(Mock())
+        with self.assertRaises(IncompleteJobTemplateException) as raised_exception:
+            job_template_loader.validate_job_file_data()
+        self.assertEqual(str(raised_exception.exception),
+                         'Please fill in placeholder values for field(s): fund_code, name')
+
+    @patch('bespin.jobtemplate.yaml')
+    def test_validate_job_file_data_invalid_job_order_params(self, mock_yaml):
+        mock_yaml.load.return_value = {
+            'name': 'myjob',
+            'fund_code': '0001',
+            'job_order': {
+                'intval': INT_VALUE_PLACEHOLDER,
+                'fileval': {
+                    'class': 'File',
+                    'path': FILE_PLACEHOLDER
+                },
+                'otherint': 123,
+                'otherfile': {
+                    'class': 'File',
+                    'path': 'somefile.txt'
+                },
+            },
+            'tag': 'mytag',
+        }
+        job_template_loader = JobTemplateLoader(Mock())
+        with self.assertRaises(IncompleteJobTemplateException) as raised_exception:
+            job_template_loader.validate_job_file_data()
+        self.assertEqual(str(raised_exception.exception),
+                         'Please fill in placeholder values for field(s): job_order.fileval, job_order.intval')
+
+
+class JobConfigurationTestCase(TestCase):
+    def test_create_job_file_with_placeholders(self):
+        configuration = JobConfiguration({
+            'tag': 'mytag',
+            'user_fields': {}
+        })
+        job_file = configuration.create_job_template_with_placeholders()
+        self.assertEqual(job_file.tag, 'mytag')
+        self.assertEqual(job_file.name, STRING_VALUE_PLACEHOLDER)
+        self.assertEqual(job_file.fund_code, STRING_VALUE_PLACEHOLDER)
+        self.assertEqual(job_file.job_order, {})
+
+    def test_format_user_fields(self):
+        user_fields = [
+            {"type": "int", "name": "myint"},
+            {"type": "string", "name": "mystr"},
+            {"type": {"type": "array",  "items": "int"}, "name": "intary"}
+        ]
+        configuration = JobConfiguration({
+            'tag': 'mytag',
+            'user_fields': user_fields,
+        })
+        user_fields = configuration.format_user_fields()
+        self.assertEqual(user_fields, {
+            'intary': [INT_VALUE_PLACEHOLDER], 'myint': INT_VALUE_PLACEHOLDER, 'mystr': STRING_VALUE_PLACEHOLDER
+        })
+
+    def test_create_placeholder_value(self):
+        configuration = JobConfiguration({
+            'tag': 'mytag',
+            'user_fields': {}
+        })
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='string', is_array=False),
+            STRING_VALUE_PLACEHOLDER)
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='int', is_array=False),
+            INT_VALUE_PLACEHOLDER)
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='int', is_array=True),
+            [INT_VALUE_PLACEHOLDER])
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='File', is_array=False),
+            {
+                "class": "File",
+                "path": FILE_PLACEHOLDER
+            })
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='File', is_array=True),
+            [{
+                "class": "File",
+                "path": FILE_PLACEHOLDER
+            }])
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=False),
+            {
+                "name": STRING_VALUE_PLACEHOLDER,
+                "file1": {
+                    "class": "File",
+                    "path": FILE_PLACEHOLDER
+                },
+                "file2": {
+                    "class": "File",
+                    "path": FILE_PLACEHOLDER
+                }
+            })
+        self.assertEqual(
+            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=True),
+            [{
+                "name": STRING_VALUE_PLACEHOLDER,
+                "file1": {
+                    "class": "File",
+                    "path": FILE_PLACEHOLDER
+                },
+                "file2": {
+                    "class": "File",
+                    "path": FILE_PLACEHOLDER
+                }
+            }])
+
+
+class JobOrderWalkerTestCase(TestCase):
+    def test_walk(self):
+        walker = JobOrderWalker()
+        walker.on_class_value = Mock()
+        walker.on_simple_value = Mock()
+        walker.walk({
+            'color': 'red',
+            'weight': 123,
+            'file1': {
+                'class': 'File',
+                'path': 'somepath'
+            },
+            'file_ary': [
+                {
+                    'class': 'File',
+                    'path': 'somepath1'
+                }, {
+                    'class': 'File',
+                    'path': 'somepath2'
+                },
+            ],
+            'nested': {
+                'a': [{
+                    'class': 'File',
+                    'path': 'somepath3'
+                }]
+            },
+            'plain_path_file': {
+                'class': 'File',
+                'path': '/tmp/data.txt'
+            },
+            'url_file': {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+            },
+        })
+
+        walker.on_simple_value.assert_has_calls([
+            call('color', 'red'),
+            call('weight', 123),
+        ])
+        walker.on_class_value.assert_has_calls([
+            call('file1', {'class': 'File', 'path': 'somepath'}),
+            call('file_ary', {'class': 'File', 'path': 'somepath1'}),
+            call('file_ary', {'class': 'File', 'path': 'somepath2'}),
+            call('nested', {'class': 'File', 'path': 'somepath3'}),
+        ])
+
+    def test_format_file_path(self):
+        data = [
+            # input    expected
+            ('https://placeholder.data/stuff/data.txt', 'https://placeholder.data/stuff/data.txt'),
+            ('dds://myproject/rawData/SAAAA_R1_001.fastq.gz', 'dds_myproject_rawData_SAAAA_R1_001.fastq.gz'),
+            ('dds://project/somepath.txt', 'dds_project_somepath.txt'),
+            ('dds://project/dir/somepath.txt', 'dds_project_dir_somepath.txt'),
+        ]
+        for input_val, expected_val in data:
+            self.assertEqual(JobOrderWalker.format_file_path(input_val), expected_val)
+
+
+class JobOrderPlaceholderCheckTestCase(TestCase):
+    def test_walk(self):
+        job_order = {
+            'good_str': 'a',
+            'bad_str': STRING_VALUE_PLACEHOLDER,
+            'good_int': 123,
+            'bad_int': INT_VALUE_PLACEHOLDER,
+            'good_file': {
+                'class': 'File',
+                'path': 'somepath.txt',
+            },
+            'bad_file': {
+                'class': 'File',
+                'path': FILE_PLACEHOLDER,
+            },
+            'good_str_ary': ['a', 'b', 'c'],
+            'bad_str_ary': ['a', STRING_VALUE_PLACEHOLDER, 'c'],
+            'good_file_ary': [{
+                'class': 'File',
+                'path': 'somepath.txt',
+            }],
+            'bad_file_ary': [{
+                'class': 'File',
+                'path': FILE_PLACEHOLDER,
+            }],
+            'good_file_dict': {
+                'stuff': {
+                    'class': 'File',
+                    'path': 'somepath.txt',
+                }
+            },
+            'bad_file_dict': {
+                'stuff': {
+                    'class': 'File',
+                    'path': FILE_PLACEHOLDER,
+                }
+            },
+            'plain_path_file': {
+                'class': 'File',
+                'path': '/tmp/data.txt'
+            },
+            'url_file': {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+            },
+        }
+        expected_keys = [
+            'bad_str', 'bad_int', 'bad_file', 'bad_str_ary', 'bad_file_ary', 'bad_file_dict',
+        ]
+
+        checker = JobOrderPlaceholderCheck()
+        checker.walk(job_order)
+
+        self.assertEqual(checker.keys_with_placeholders, set(expected_keys))
+
+
+class JobOrderFormatFilesTestCase(TestCase):
+    def test_walk(self):
+        job_order = {
+            'good_str': 'a',
+            'good_int': 123,
+            'good_file': {
+                'class': 'File',
+                'path': 'dds://project1/data/somepath.txt',
+            },
+            'good_str_ary': ['a', 'b', 'c'],
+            'good_file_ary': [{
+                'class': 'File',
+                'path': 'dds://project2/data/somepath2.txt',
+            }],
+            'good_file_dict': {
+                'stuff': {
+                    'class': 'File',
+                    'path': 'dds://project3/data/other/somepath.txt',
+                }
+            },
+            'plain_path_file': {
+                'class': 'File',
+                'path': '/tmp/data.txt'
+            },
+            'url_file': {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+            },
+        }
+
+        formatter = JobOrderFormatFiles()
+        formatter.walk(job_order)
+
+        self.assertEqual(job_order['good_str'], 'a')
+        self.assertEqual(job_order['good_int'], 123)
+        self.assertEqual(job_order['good_file'],
+                         {'class': 'File', 'path': 'dds_project1_data_somepath.txt'})
+        self.assertEqual(job_order['good_str_ary'], ['a', 'b', 'c'])
+        self.assertEqual(job_order['good_file_ary'],
+                         [{'class': 'File', 'path': 'dds_project2_data_somepath2.txt'}])
+        self.assertEqual(job_order['good_file_dict'],
+                         {'stuff': {'class': 'File', 'path': 'dds_project3_data_other_somepath.txt'}})
+
+
+class JobOrderFileDetailsTestCase(TestCase):
+    @patch('bespin.jobtemplate.DDSFileUtil')
+    def test_walk(self, mock_dds_file_util):
+        mock_dds_file_util.return_value.find_file_for_path.return_value = 'ddsfiledata'
+        job_order = {
+            'good_str': 'a',
+            'good_int': 123,
+            'good_file': {
+                'class': 'File',
+                'path': 'dds://project1/data/somepath.txt',
+            },
+            'good_str_ary': ['a', 'b', 'c'],
+            'good_file_ary': [{
+                'class': 'File',
+                'path': 'dds://project2/data/somepath2.txt',
+            }],
+            'good_file_dict': {
+                'stuff': {
+                    'class': 'File',
+                    'path': 'dds://project3/data/other/somepath.txt',
+                }
+            },
+            'plain_path_file': {
+                'class': 'File',
+                'path': '/tmp/data.txt'
+            },
+            'url_file': {
+                'class': 'File',
+                'location': 'https://github.com/datafile1.dat'
+            },
+        }
+        expected_dds_file_info = [
+            ('ddsfiledata', 'dds_project1_data_somepath.txt'),
+            ('ddsfiledata', 'dds_project2_data_somepath2.txt'),
+            ('ddsfiledata', 'dds_project3_data_other_somepath.txt')
+        ]
+
+        details = JobOrderFileDetails()
+        details.walk(job_order)
+
+        self.assertEqual(details.dds_files, expected_dds_file_info)
+

--- a/bespin/test_jobtemplate.py
+++ b/bespin/test_jobtemplate.py
@@ -532,4 +532,3 @@ class JobOrderFileDetailsTestCase(TestCase):
         details.walk(job_order)
 
         self.assertEqual(details.dds_files, expected_dds_file_info)
-

--- a/bespin/test_workflow.py
+++ b/bespin/test_workflow.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from unittest import TestCase
+import yaml
+import json
+from bespin.workflow import CWLWorkflowVersion
+from mock import patch, call, Mock
+
+
+class CWLWorkflowVersionTestCase(TestCase):
+    def setUp(self):
+        self.cwl_workflow_version = CWLWorkflowVersion(workflow_tag="sometag", url="someurl",
+                                                       description="SomeDesc", version=1)
+
+    @patch('bespin.workflow.load_tool')
+    def test_create(self, mock_load_tool):
+        mock_api = Mock()
+        mock_api.workflow_get_for_tag.return_value = {'id': 1}
+        response = self.cwl_workflow_version.create(mock_api)
+        mock_fields = mock_load_tool.return_value.inputs_record_schema.get.return_value
+        mock_api.workflow_versions_post.assert_called_with(workflow=1, version_num=1, description="SomeDesc",
+                                                           url="someurl", fields=mock_fields)
+
+    def test_get_workflow_id(self):
+        mock_api = Mock()
+        mock_api.workflow_get_for_tag.return_value = {'id': 2}
+        response = self.cwl_workflow_version.get_workflow_id(mock_api)
+        self.assertEqual(response, 2)
+
+    def test_get_version_num(self):
+        mock_api = Mock()
+        self.cwl_workflow_version.version = 2
+        self.assertEqual(self.cwl_workflow_version.get_version_num(mock_api), 2)
+        mock_api.workflow_versions_list.assert_not_called()
+
+        mock_api.workflow_versions_list.return_value = [
+            {'version': 1},
+            {'version': 2},
+        ]
+        self.cwl_workflow_version.version = 'auto'
+        self.assertEqual(self.cwl_workflow_version.get_version_num(mock_api), 3)
+        mock_api.workflow_versions_list.assert_called_with('sometag')
+
+    @patch('bespin.workflow.load_tool')
+    def test_get_fields_from_url(self, mock_load_tool):
+        response = self.cwl_workflow_version.get_fields_from_url()
+        self.assertEqual(response, mock_load_tool.return_value.inputs_record_schema.get.return_value)
+        mock_load_tool.return_value.inputs_record_schema.get.assert_called_with("fields")

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -1,0 +1,34 @@
+from cwltool.context import LoadingContext
+from cwltool.workflow import default_make_tool
+from cwltool.resolver import tool_resolver
+from cwltool.load_tool import load_tool
+import logging
+
+
+class CWLWorkflowVersion(object):
+    def __init__(self, workflow, version_num, description, url):
+        self.workflow = workflow
+        self.version_num = version_num
+        self.description = description
+        self.url = url
+
+    def create(self, api):
+        fields = self.get_fields_from_url()
+        return api.workflow_versions_post(
+            workflow=self.workflow,
+            version_num=self.version_num,
+            description=self.description,
+            url=self.url,
+            fields=fields
+        )
+
+    def get_fields_from_url(self):
+        # turn off default cwltool INFO logging
+        cwl_logger = logging.getLogger("cwltool")
+        cwl_logger.setLevel(logging.ERROR)
+        context = LoadingContext({"construct_tool_object": default_make_tool,
+                                  "resolver": tool_resolver,
+                                  "disable_js_validation": True})
+        context.strict = False
+        parsed = load_tool(self.url + '#main', context)
+        return parsed.inputs_record_schema.get('fields')

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -2,25 +2,39 @@ from cwltool.context import LoadingContext
 from cwltool.workflow import default_make_tool
 from cwltool.resolver import tool_resolver
 from cwltool.load_tool import load_tool
+from bespin.exceptions import WorkflowNotFound
 import logging
+
+AUTO_VERSION_VALUE = 'auto'
 
 
 class CWLWorkflowVersion(object):
-    def __init__(self, workflow, version_num, description, url):
-        self.workflow = workflow
-        self.version_num = version_num
-        self.description = description
+    def __init__(self, workflow_tag, url, description, version):
+        self.workflow_tag = workflow_tag
         self.url = url
+        self.description = description
+        self.version = version
 
     def create(self, api):
-        fields = self.get_fields_from_url()
         return api.workflow_versions_post(
-            workflow=self.workflow,
-            version_num=self.version_num,
+            workflow=self.get_workflow_id(api),
+            version_num=self.get_version_num(api),
             description=self.description,
             url=self.url,
-            fields=fields
+            fields=self.get_fields_from_url()
         )
+
+    def get_workflow_id(self, api):
+        return api.workflow_get_for_tag(self.workflow_tag)['id']
+
+    def get_version_num(self, api):
+        if self.version == AUTO_VERSION_VALUE:
+            items = api.workflow_versions_list(self.workflow_tag)
+            if not items:
+                return 1
+            else:
+                return items[-1]['version'] + 1
+        return self.version
 
     def get_fields_from_url(self):
         # turn off default cwltool INFO logging

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(name='bespin-cli',
           'requests',
           'six',
           'tabulate',
+          'cwltool==1.0.20181118133959',
+          'html5lib==1.0.1',
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Fixes #24
Reworked command line options to be more consistent.
Command line organization is based on https://github.com/Duke-GCB/bespin-cli/issues/24#issuecomment-443001611

Some new commands (creating workflows, workflow versions, and workflow configuration) require admin access in bespin-api right now, but this should change when https://github.com/Duke-GCB/bespin-api/issues/172 is finished.

 Requires https://github.com/Duke-GCB/bespin-api/pull/178