### PR TITLE
use bespin-api job-template/validate method

### DIFF
--- a/bespin/api.py
+++ b/bespin/api.py
@@ -62,7 +62,7 @@ class BespinApi(object):
         try:
             response.raise_for_status()
         except requests.HTTPError:
-            raise BespinException(message)
+            raise BespinException(BespinApi.make_message_for_http_error(response))
 
     @staticmethod
     def make_message_for_http_error(response):

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -54,26 +54,26 @@ class BespinApi(object):
 
     @staticmethod
     def _check_response(response):
-
-        if response.status_code == 404:
-            raise NotFoundException(BespinApi.make_message_for_http_error(response))
-        if 400 <= response.status_code < 500:
-            raise BespinClientErrorException(BespinApi.make_message_for_http_error(response))
         try:
             response.raise_for_status()
         except requests.HTTPError:
-            raise BespinException(BespinApi.make_message_for_http_error(response))
+            msg = BespinApi.make_message_for_http_error(response)
+            if response.status_code == 404:
+                raise NotFoundException(msg)
+            elif 400 <= response.status_code < 500:
+                raise BespinClientErrorException(msg)
+            else:
+                raise BespinException(msg)
 
     @staticmethod
     def make_message_for_http_error(response):
-        message = response.text
         try:
             data = response.json()
             if 'detail' in data:
-                message = data['detail']
+                return data['detail']
         except ValueError:
             pass  # response was not JSON
-        return message
+        return response.text
 
     def jobs_list(self):
         return self._get_request('/jobs/')

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -54,12 +54,15 @@ class BespinApi(object):
 
     @staticmethod
     def _check_response(response):
+
+        if response.status_code == 404:
+            raise NotFoundException(BespinApi.make_message_for_http_error(response))
+        if 400 <= response.status_code < 500:
+            raise BespinClientErrorException(BespinApi.make_message_for_http_error(response))
         try:
-            if response.status_code == 404:
-                raise NotFoundException(BespinApi.make_message_for_http_error(response))
             response.raise_for_status()
         except requests.HTTPError:
-            raise BespinException(BespinApi.make_message_for_http_error(response))
+            raise BespinException(message)
 
     @staticmethod
     def make_message_for_http_error(response):
@@ -234,6 +237,10 @@ class BespinApi(object):
 
 
 class BespinException(Exception):
+    pass
+
+
+class BespinClientErrorException(Exception):
     pass
 
 

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -164,6 +164,9 @@ class BespinApi(object):
     def job_templates_init(self, tag):
         return self._post_request('/job-templates/init/', {'tag': tag})
 
+    def job_template_validate(self, job_file_payload):
+        return self._post_request('/job-templates/validate/', job_file_payload)
+
     def job_templates_create_job(self, job_file_payload):
         return self._post_request('/job-templates/create-job/', job_file_payload)
 

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -1,12 +1,13 @@
 from __future__ import print_function
 from bespin.config import ConfigFile
-from bespin.api import BespinApi
+from bespin.api import BespinApi, BespinException
 from bespin.workflow import CWLWorkflowVersion
 from bespin.jobtemplate import JobTemplateLoader
 from bespin.exceptions import WorkflowConfigurationNotFoundException
 from tabulate import tabulate
 import yaml
 import sys
+import json
 from decimal import Decimal, ROUND_HALF_UP
 
 
@@ -153,8 +154,15 @@ class Commands(object):
         """
         api = self._create_api()
         job_template = JobTemplateLoader(job_template_infile).create_job_template()
-        job_template.verify_job(api)
-        print("Job file is valid.")
+        try:
+            job_template.validate(api)
+            print("Job file is valid.")
+        except BespinException as ex:
+            print("ERROR: Job template is INVALID.")
+            details = json.loads(str(ex))
+            for key in details:
+                for issue in details[key]:
+                    print("{}: {}".format(key, issue))
 
     def start_job(self, job_id, token=None):
         """

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -1,13 +1,12 @@
 from __future__ import print_function
 from bespin.config import ConfigFile
-from bespin.api import BespinApi, BespinException
+from bespin.api import BespinApi
 from bespin.workflow import CWLWorkflowVersion
 from bespin.jobtemplate import JobTemplateLoader
-from bespin.exceptions import WorkflowConfigurationNotFoundException
+from bespin.exceptions import WorkflowConfigurationNotFoundException, UserInputException
 from tabulate import tabulate
 import yaml
 import sys
-import json
 from decimal import Decimal, ROUND_HALF_UP
 
 
@@ -157,12 +156,9 @@ class Commands(object):
         try:
             job_template.validate(api)
             print("Job file is valid.")
-        except BespinException as ex:
-            print("ERROR: Job template is INVALID.")
-            details = json.loads(str(ex))
-            for key in details:
-                for issue in details[key]:
-                    print("{}: {}".format(key, issue))
+        except UserInputException:
+            print("ERROR: Job template is invalid.")
+            raise
 
     def start_job(self, job_id, token=None):
         """

--- a/bespin/jobtemplate.py
+++ b/bespin/jobtemplate.py
@@ -1,4 +1,4 @@
-from bespin.exceptions import IncompleteJobTemplateException, WorkflowConfigurationNotFoundException
+from bespin.exceptions import WorkflowConfigurationNotFoundException
 from bespin.dukeds import DDSFileUtil
 from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
 import yaml
@@ -101,7 +101,6 @@ class JobTemplateLoader(object):
                                    fund_code=self.data.get('fund_code'),
                                    job_order=self.data.get('job_order'))
         return job_template
-
 
 
 class JobOrderWalker(object):

--- a/bespin/jobtemplate.py
+++ b/bespin/jobtemplate.py
@@ -2,6 +2,7 @@ from bespin.exceptions import WorkflowConfigurationNotFoundException
 from bespin.dukeds import DDSFileUtil
 from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
 import yaml
+import copy
 
 
 class JobTemplate(object):
@@ -20,7 +21,7 @@ class JobTemplate(object):
         Format job order replacing dds remote file paths with filenames that will be staged
         :return: dict: job order for running CWL
         """
-        user_job_order = self.job_order.copy()
+        user_job_order = copy.deepcopy(self.job_order)
         formatter = JobOrderFormatFiles()
         formatter.walk(user_job_order)
         return user_job_order

--- a/bespin/jobtemplate.py
+++ b/bespin/jobtemplate.py
@@ -3,41 +3,6 @@ from bespin.dukeds import DDSFileUtil
 from bespin.dukeds import PATH_PREFIX as DUKEDS_PATH_PREFIX
 import yaml
 
-STRING_VALUE_PLACEHOLDER = "<String Value>"
-INT_VALUE_PLACEHOLDER = "<Integer Value>"
-FILE_PLACEHOLDER = "dds://<Project Name>/<File Path>"
-USER_PLACEHOLDER_VALUES = [STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, FILE_PLACEHOLDER]
-USER_PLACEHOLDER_DICT = {
-    'File': {
-        "class": "File",
-        "path": FILE_PLACEHOLDER
-    },
-    'int': INT_VALUE_PLACEHOLDER,
-    'string': STRING_VALUE_PLACEHOLDER,
-    'NamedFASTQFilePairType': {
-        "name": STRING_VALUE_PLACEHOLDER,
-        "file1": {
-            "class": "File",
-            "path": FILE_PLACEHOLDER
-        },
-        "file2": {
-            "class": "File",
-            "path": FILE_PLACEHOLDER
-        }
-    },
-    'FASTQReadPairType': {
-        "name": STRING_VALUE_PLACEHOLDER,
-        "read1_files": [{
-            "class": "File",
-            "path": FILE_PLACEHOLDER
-        }],
-        "read2_files": [{
-            "class": "File",
-            "path": FILE_PLACEHOLDER
-        }]
-    }
-}
-
 
 class JobTemplate(object):
     """
@@ -49,17 +14,6 @@ class JobTemplate(object):
         self.fund_code = fund_code
         self.job_order = job_order
         self.stage_group_id = None
-
-    def to_dict(self):
-        data = {
-            'name': self.name,
-            'fund_code': self.fund_code,
-            'job_order': self.job_order,
-            'tag': self.tag,
-        }
-        if self.stage_group_id:
-            data['stage_group'] = self.stage_group_id
-        return data
 
     def create_user_job_order(self):
         """
@@ -108,17 +62,30 @@ class JobTemplate(object):
                                          size=file_size)
             sequence += 1
             dds_project_ids.add(dds_file.project_id)
-        self.job_order = self.create_user_job_order()
-        job = api.job_templates_create_job(self.to_dict())
+
+        job = api.job_templates_create_job(self.get_formatted_dict())
         dds_file_util = DDSFileUtil()
         for project_id in dds_project_ids:
             dds_file_util.give_download_permissions(project_id, dds_user_credential['dds_id'])
         return job
 
-    def verify_job(self, api):
-        self.read_workflow_configuration(api)  # workflow configuration must exist
-        self.get_dds_files_details()  # DukeDS input files must exist
-        self.create_user_job_order()  # verify that we can generate a job order
+    def validate(self, api):
+        # check with bespin-api to see if the job order is valid
+        api.job_template_validate(self.get_formatted_dict())
+        # make sure DukeDS files exist (this takes longer)
+        self.get_dds_files_details()
+
+    def get_formatted_dict(self):
+        formatted_job_order = self.create_user_job_order()
+        data = {
+            'name': self.name,
+            'fund_code': self.fund_code,
+            'job_order': formatted_job_order,
+            'tag': self.tag,
+        }
+        if self.stage_group_id:
+            data['stage_group'] = self.stage_group_id
+        return data
 
 
 class JobTemplateLoader(object):
@@ -129,64 +96,12 @@ class JobTemplateLoader(object):
         self.data = yaml.load(infile)
 
     def create_job_template(self):
-        self.validate_job_file_data()
-        job_template = JobTemplate(tag=self.data['tag'],
-                                   name=self.data['name'],
-                                   fund_code=self.data['fund_code'],
-                                   job_order=self.data['job_order'])
+        job_template = JobTemplate(tag=self.data.get('tag'),
+                                   name=self.data.get('name'),
+                                   fund_code=self.data.get('fund_code'),
+                                   job_order=self.data.get('job_order'))
         return job_template
 
-    def validate_job_file_data(self):
-        bad_fields = []
-        for field_name in ['name', 'fund_code']:
-            if self.data[field_name] in USER_PLACEHOLDER_VALUES:
-                bad_fields.append(field_name)
-        checker = JobOrderPlaceholderCheck()
-        checker.walk(self.data['job_order'])
-        bad_fields.extend(['job_order.{}'.format(key) for key in checker.keys_with_placeholders])
-        if bad_fields:
-            bad_fields.sort()
-            bad_fields_str = ', '.join(bad_fields)
-            error_msg = "Please fill in placeholder values for field(s): {}".format(bad_fields_str)
-            raise IncompleteJobTemplateException(error_msg)
-
-
-class JobConfiguration(object):
-    """
-    Creates a placeholder job file based on workflow_configuration
-    """
-    def __init__(self, workflow_configuration):
-        self.workflow_configuration = workflow_configuration
-
-    def create_job_template_with_placeholders(self):
-        return JobTemplate(tag=self.workflow_configuration['tag'],
-                           name=STRING_VALUE_PLACEHOLDER, fund_code=STRING_VALUE_PLACEHOLDER,
-                           job_order=self.format_user_fields())
-
-    def format_user_fields(self):
-        user_fields = self.workflow_configuration['user_fields']
-        formatted_user_fields = {}
-        for user_field in user_fields:
-            field_type = user_field.get('type')
-            field_name = user_field.get('name')
-            if isinstance(field_type, dict):
-                if field_type['type'] == 'array':
-                    value = self.create_placeholder_value(field_type['items'], is_array=True)
-                else:
-                    value = self.create_placeholder_value(field_type['type'], is_array=False)
-            else:
-                value = self.create_placeholder_value(field_type, is_array=False)
-            formatted_user_fields[field_name] = value
-        return formatted_user_fields
-
-    def create_placeholder_value(self, type_name, is_array):
-        if is_array:
-            return [self.create_placeholder_value(type_name, is_array=False)]
-        else:  # single item type
-            placeholder = USER_PLACEHOLDER_DICT.get(type_name)
-            if not placeholder:
-                return STRING_VALUE_PLACEHOLDER
-            return placeholder
 
 
 class JobOrderWalker(object):
@@ -227,21 +142,6 @@ class JobOrderWalker(object):
         if path.startswith(DUKEDS_PATH_PREFIX):
             return path.replace(DUKEDS_PATH_PREFIX, "dds_").replace("/", "_").replace(":", "_")
         return path
-
-
-class JobOrderPlaceholderCheck(JobOrderWalker):
-    def __init__(self):
-        self.keys_with_placeholders = set()
-
-    def on_class_value(self, top_level_key, value):
-        if value['class'] == 'File':
-            path = value.get('path')
-            if path and path in USER_PLACEHOLDER_VALUES:
-                self.keys_with_placeholders.add(top_level_key)
-
-    def on_simple_value(self, top_level_key, value):
-        if value in USER_PLACEHOLDER_VALUES:
-            self.keys_with_placeholders.add(top_level_key)
 
 
 class JobOrderFormatFiles(JobOrderWalker):

--- a/bespin/jobtemplate.py
+++ b/bespin/jobtemplate.py
@@ -78,12 +78,19 @@ class JobTemplate(object):
             # make sure DukeDS files exist (this takes longer)
             self.get_dds_files_details()
         except BespinException as ex:
+            self.flatten_bespin_exception(ex)
+
+    def flatten_bespin_exception(self, ex):
+        try:
             details = json.loads(str(ex))
-            message = ""
+            issues = []
             for key in details:
-                for issue in details[key]:
-                    message += "{}: {}\n".format(key, issue)
-            raise IncompleteJobTemplateException(message)
+                for problem in details[key]:
+                    issues.append("{}: {}".format(key, problem))
+            message = '\n'.join(issues)
+        except json.JSONDecodeError as e:
+            message = str(ex)
+        raise IncompleteJobTemplateException(message)
 
     def get_formatted_dict(self):
         formatted_job_order = self.create_user_job_order()

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -450,6 +450,7 @@ class BespinApiTestCase(TestCase):
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
         mock_response = Mock()
         mock_response.json.return_value = {'field1': ['bad']}
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
 
         mock_response.status_code = 400
         with self.assertRaises(BespinClientErrorException):
@@ -462,6 +463,10 @@ class BespinApiTestCase(TestCase):
         mock_response.status_code = 404
         with self.assertRaises(NotFoundException):
             api._check_response(mock_response)
+
+        mock_response = Mock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status.return_value = None
 
         mock_response.status_code = 200
         api._check_response(mock_response)

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from bespin.api import BespinApi, BespinException, NotFoundException, requests
+from bespin.api import BespinApi, BespinException, BespinClientErrorException, NotFoundException, requests
 from mock import patch, Mock
 
 
@@ -43,7 +43,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_jobs_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['job1', 'job2']
         mock_requests.get.return_value = mock_response
 
@@ -55,7 +55,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflows_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflow1', 'workflow2']
         mock_requests.get.return_value = mock_response
 
@@ -67,7 +67,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflows_list_with_filter(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflow1', 'workflow2']
         mock_requests.get.return_value = mock_response
 
@@ -79,7 +79,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_get(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'workflow1'
         mock_requests.get.return_value = mock_response
 
@@ -91,7 +91,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_get_for_tag(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflow1']
         mock_requests.get.return_value = mock_response
 
@@ -103,7 +103,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_post(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'workflow1'
         mock_requests.post.return_value = mock_response
 
@@ -116,7 +116,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_versions_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflowversion1', 'workflowversion2']
         mock_requests.get.return_value = mock_response
 
@@ -128,7 +128,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_versions_list_with_filter(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflowversion1', 'workflowversion2']
         mock_requests.get.return_value = mock_response
 
@@ -141,7 +141,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_version_get(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'workflowversion1'
         mock_requests.get.return_value = mock_response
 
@@ -153,7 +153,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_versions_post(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'worflow_version1'
         mock_requests.post.return_value = mock_response
 
@@ -173,7 +173,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_stage_group_post(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'stagegroup1'
         mock_requests.post.return_value = mock_response
 
@@ -185,7 +185,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_dds_job_input_files_post(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'dds-job-input-file1'
         mock_requests.post.return_value = mock_response
 
@@ -211,7 +211,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_authorize_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job1'
         mock_requests.post.return_value = mock_response
 
@@ -224,7 +224,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_start_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job1'
         mock_requests.post.return_value = mock_response
 
@@ -237,7 +237,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_cancel_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job1'
         mock_requests.post.return_value = mock_response
 
@@ -250,7 +250,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_restart_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job1'
         mock_requests.post.return_value = mock_response
 
@@ -263,7 +263,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_delete_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_requests.delete.return_value = mock_response
 
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
@@ -273,7 +273,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_dds_user_credentials_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['agentcred1']
         mock_requests.get.return_value = mock_response
 
@@ -285,7 +285,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_configurations_list_no_filtering(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflowconfig1']
         mock_requests.get.return_value = mock_response
 
@@ -296,7 +296,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_configurations_list_with_filtering(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['workflowconfig1']
         mock_requests.get.return_value = mock_response
 
@@ -311,7 +311,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_configurations_get(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'workflow1'
         mock_requests.get.return_value = mock_response
 
@@ -323,7 +323,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_workflow_configurations_post(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'workflowconfiguration1'
         mock_requests.post.return_value = mock_response
 
@@ -347,7 +347,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_job_templates_init(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job_template1'
         mock_requests.post.return_value = mock_response
 
@@ -363,7 +363,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_job_templates_create_job(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'job_template_filled_in'
         mock_requests.post.return_value = mock_response
 
@@ -376,7 +376,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_share_groups_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['sharegroup1']
         mock_requests.get.return_value = mock_response
 
@@ -388,7 +388,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_share_group_get(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'sharegroup1'
         mock_requests.get.return_value = mock_response
 
@@ -400,7 +400,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_share_group_get_for_name(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['sharegroup1']
         mock_requests.get.return_value = mock_response
 
@@ -412,7 +412,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_vm_strategies_list(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['vmstrategy1']
         mock_requests.get.return_value = mock_response
 
@@ -424,7 +424,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_vm_strategy_get(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = 'vmstrategy1'
         mock_requests.get.return_value = mock_response
 
@@ -436,7 +436,7 @@ class BespinApiTestCase(TestCase):
 
     @patch('bespin.api.requests')
     def test_vm_strategy_get_for_name(self, mock_requests):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['vmstrategy1']
         mock_requests.get.return_value = mock_response
 
@@ -445,3 +445,26 @@ class BespinApiTestCase(TestCase):
 
         self.assertEqual(response, 'vmstrategy1')
         mock_requests.get.assert_called_with('someurl/vm-strategies/?name=myname', headers=self.expected_headers)
+
+    def test_check_response_raising_exceptions(self):
+        api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
+        mock_response = Mock()
+        mock_response.json.return_value = {'field1': ['bad']}
+
+        mock_response.status_code = 400
+        with self.assertRaises(BespinClientErrorException):
+            api._check_response(mock_response)
+
+        mock_response.status_code = 401
+        with self.assertRaises(BespinClientErrorException):
+            api._check_response(mock_response)
+
+        mock_response.status_code = 404
+        with self.assertRaises(NotFoundException):
+            api._check_response(mock_response)
+
+        mock_response.status_code = 200
+        api._check_response(mock_response)
+
+        mock_response.status_code = 201
+        api._check_response(mock_response)

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 from bespin.commands import Commands, Table, ShortWorkflowDetails, FullWorkflowDetails, JobsList, \
     WorkflowVersionsList, WorkflowConfigurationsList, ShareGroupsList, VmStrategiesList
+from bespin.exceptions import UserInputException
 from mock import patch, call, Mock
 
 
@@ -117,6 +118,21 @@ class CommandsTestCase(TestCase):
         mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
         mock_job_template.validate.assert_called_with(mock_bespin_api.return_value)
         mock_print.assert_called_with('Job file is valid.')
+
+    @patch('bespin.commands.ConfigFile')
+    @patch('bespin.commands.BespinApi')
+    @patch('bespin.commands.JobTemplateLoader')
+    @patch('bespin.commands.print')
+    def test_job_validate_exception(self, mock_print, mock_job_template_loader, mock_bespin_api, mock_config_file):
+        mock_infile = Mock()
+        mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
+        mock_job_template.validate.side_effect = UserInputException("Bad data")
+
+        commands = Commands(self.version_str, self.user_agent_str)
+        with self.assertRaises(UserInputException):
+            commands.job_validate(job_template_infile=mock_infile)
+
+        mock_print.assert_called_with('ERROR: Job template is invalid.')
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -55,9 +55,8 @@ class CommandsTestCase(TestCase):
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
-    @patch('bespin.jobtemplate.JobConfiguration')
     @patch('bespin.commands.print')
-    def test_job_template_create(self, mock_print, mock_job_configuration, mock_bespin_api, mock_config_file):
+    def test_job_template_create(self, mock_print, mock_bespin_api, mock_config_file):
         mock_outfile = Mock()
         mock_bespin_api.return_value.job_templates_init.return_value = {}
 
@@ -116,7 +115,7 @@ class CommandsTestCase(TestCase):
 
         mock_job_template_loader.assert_called_with(mock_infile)
         mock_job_template = mock_job_template_loader.return_value.create_job_template.return_value
-        mock_job_template.verify_job.assert_called_with(mock_bespin_api.return_value)
+        mock_job_template.validate.assert_called_with(mock_bespin_api.return_value)
         mock_print.assert_called_with('Job file is valid.')
 
     @patch('bespin.commands.ConfigFile')

--- a/bespin/test_jobtemplate.py
+++ b/bespin/test_jobtemplate.py
@@ -2,14 +2,14 @@ from __future__ import absolute_import
 from unittest import TestCase
 import yaml
 import json
-from bespin.jobtemplate import JobTemplate, JobTemplateLoader, JobConfiguration, JobOrderWalker, JobOrderFileDetails, \
-    JobOrderFormatFiles, JobOrderPlaceholderCheck, STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, FILE_PLACEHOLDER
+from bespin.jobtemplate import JobTemplate, JobTemplateLoader, JobOrderWalker, JobOrderFileDetails, \
+    JobOrderFormatFiles
 from bespin.exceptions import IncompleteJobTemplateException
 from mock import patch, call, Mock
 
 
 class JobTemplateTestCase(TestCase):
-    def test_to_dict(self):
+    def test_get_formatted_dict(self):
         job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={})
         expected_dict = {
             'fund_code': '001',
@@ -17,7 +17,7 @@ class JobTemplateTestCase(TestCase):
             'name': 'myjob',
             'tag': 'sometag'
         }
-        self.assertEqual(job_template.to_dict(), expected_dict)
+        self.assertEqual(job_template.get_formatted_dict(), expected_dict)
 
     def test_create_user_job_order_json(self):
         job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
@@ -150,7 +150,7 @@ class JobTemplateTestCase(TestCase):
 
     @patch('bespin.jobtemplate.DDSFileUtil')
     @patch('bespin.jobtemplate.JobOrderFormatFiles')
-    def test_verify_job(self, mock_job_order_format_files, mock_dds_file_util):
+    def test_validate(self, mock_job_order_format_files, mock_dds_file_util):
         mock_dds_file_util.return_value.find_file_for_path.return_value = 'filedata1'
         mock_api = Mock()
         mock_api.dds_user_credentials_list.return_value = [{'id': 111, 'dds_id': 112}]
@@ -175,8 +175,18 @@ class JobTemplateTestCase(TestCase):
         mock_file.id = 777
         job_template.get_dds_files_details.return_value = [[mock_file, 'somepath']]
 
-        job_template.verify_job(mock_api)
-        mock_api.workflow_configurations_list.assert_called_with(tag='human', workflow_tag='sometag')
+        job_template.validate(mock_api)
+        mock_api.job_template_validate.assert_called_with({
+            'name': 'myjob',
+            'fund_code': '001',
+            'job_order': {
+                'myfile': {
+                    'class': 'File',
+                    'path': 'dds://project_somepath.txt'
+                },
+                'myint': 555},
+            'tag': 'sometag/v1/human'
+        })
         job_template.get_dds_files_details.assert_called_with()
         mock_job_order_format_files.return_value.walk.assert_called_with(job_order)
 
@@ -198,137 +208,6 @@ class JobFileLoaderTestCase(TestCase):
         self.assertEqual(job_template.fund_code, '0001')
         self.assertEqual(job_template.job_order, {})
         self.assertEqual(job_template.tag, 'mytag')
-
-    @patch('bespin.jobtemplate.yaml')
-    def test_validate_job_file_data_ok(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': 'myjob',
-            'fund_code': '0001',
-            'job_order': {},
-            'tag': 'mytag',
-        }
-        job_template_loader = JobTemplateLoader(Mock())
-        job_template_loader.validate_job_file_data()
-
-    @patch('bespin.jobtemplate.yaml')
-    def test_validate_job_file_data_invalid_name_and_fund_code(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': STRING_VALUE_PLACEHOLDER,
-            'fund_code': STRING_VALUE_PLACEHOLDER,
-            'job_order': {},
-            'tag': 'mytag',
-        }
-        job_template_loader = JobTemplateLoader(Mock())
-        with self.assertRaises(IncompleteJobTemplateException) as raised_exception:
-            job_template_loader.validate_job_file_data()
-        self.assertEqual(str(raised_exception.exception),
-                         'Please fill in placeholder values for field(s): fund_code, name')
-
-    @patch('bespin.jobtemplate.yaml')
-    def test_validate_job_file_data_invalid_job_order_params(self, mock_yaml):
-        mock_yaml.load.return_value = {
-            'name': 'myjob',
-            'fund_code': '0001',
-            'job_order': {
-                'intval': INT_VALUE_PLACEHOLDER,
-                'fileval': {
-                    'class': 'File',
-                    'path': FILE_PLACEHOLDER
-                },
-                'otherint': 123,
-                'otherfile': {
-                    'class': 'File',
-                    'path': 'somefile.txt'
-                },
-            },
-            'tag': 'mytag',
-        }
-        job_template_loader = JobTemplateLoader(Mock())
-        with self.assertRaises(IncompleteJobTemplateException) as raised_exception:
-            job_template_loader.validate_job_file_data()
-        self.assertEqual(str(raised_exception.exception),
-                         'Please fill in placeholder values for field(s): job_order.fileval, job_order.intval')
-
-
-class JobConfigurationTestCase(TestCase):
-    def test_create_job_file_with_placeholders(self):
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': {}
-        })
-        job_file = configuration.create_job_template_with_placeholders()
-        self.assertEqual(job_file.tag, 'mytag')
-        self.assertEqual(job_file.name, STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(job_file.fund_code, STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(job_file.job_order, {})
-
-    def test_format_user_fields(self):
-        user_fields = [
-            {"type": "int", "name": "myint"},
-            {"type": "string", "name": "mystr"},
-            {"type": {"type": "array",  "items": "int"}, "name": "intary"}
-        ]
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': user_fields,
-        })
-        user_fields = configuration.format_user_fields()
-        self.assertEqual(user_fields, {
-            'intary': [INT_VALUE_PLACEHOLDER], 'myint': INT_VALUE_PLACEHOLDER, 'mystr': STRING_VALUE_PLACEHOLDER
-        })
-
-    def test_create_placeholder_value(self):
-        configuration = JobConfiguration({
-            'tag': 'mytag',
-            'user_fields': {}
-        })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='string', is_array=False),
-            STRING_VALUE_PLACEHOLDER)
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='int', is_array=False),
-            INT_VALUE_PLACEHOLDER)
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='int', is_array=True),
-            [INT_VALUE_PLACEHOLDER])
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='File', is_array=False),
-            {
-                "class": "File",
-                "path": FILE_PLACEHOLDER
-            })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='File', is_array=True),
-            [{
-                "class": "File",
-                "path": FILE_PLACEHOLDER
-            }])
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=False),
-            {
-                "name": STRING_VALUE_PLACEHOLDER,
-                "file1": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                },
-                "file2": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                }
-            })
-        self.assertEqual(
-            configuration.create_placeholder_value(type_name='NamedFASTQFilePairType', is_array=True),
-            [{
-                "name": STRING_VALUE_PLACEHOLDER,
-                "file1": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                },
-                "file2": {
-                    "class": "File",
-                    "path": FILE_PLACEHOLDER
-                }
-            }])
 
 
 class JobOrderWalkerTestCase(TestCase):
@@ -389,62 +268,6 @@ class JobOrderWalkerTestCase(TestCase):
         ]
         for input_val, expected_val in data:
             self.assertEqual(JobOrderWalker.format_file_path(input_val), expected_val)
-
-
-class JobOrderPlaceholderCheckTestCase(TestCase):
-    def test_walk(self):
-        job_order = {
-            'good_str': 'a',
-            'bad_str': STRING_VALUE_PLACEHOLDER,
-            'good_int': 123,
-            'bad_int': INT_VALUE_PLACEHOLDER,
-            'good_file': {
-                'class': 'File',
-                'path': 'somepath.txt',
-            },
-            'bad_file': {
-                'class': 'File',
-                'path': FILE_PLACEHOLDER,
-            },
-            'good_str_ary': ['a', 'b', 'c'],
-            'bad_str_ary': ['a', STRING_VALUE_PLACEHOLDER, 'c'],
-            'good_file_ary': [{
-                'class': 'File',
-                'path': 'somepath.txt',
-            }],
-            'bad_file_ary': [{
-                'class': 'File',
-                'path': FILE_PLACEHOLDER,
-            }],
-            'good_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': 'somepath.txt',
-                }
-            },
-            'bad_file_dict': {
-                'stuff': {
-                    'class': 'File',
-                    'path': FILE_PLACEHOLDER,
-                }
-            },
-            'plain_path_file': {
-                'class': 'File',
-                'path': '/tmp/data.txt'
-            },
-            'url_file': {
-                'class': 'File',
-                'location': 'https://github.com/datafile1.dat'
-            },
-        }
-        expected_keys = [
-            'bad_str', 'bad_int', 'bad_file', 'bad_str_ary', 'bad_file_ary', 'bad_file_dict',
-        ]
-
-        checker = JobOrderPlaceholderCheck()
-        checker.walk(job_order)
-
-        self.assertEqual(checker.keys_with_placeholders, set(expected_keys))
 
 
 class JobOrderFormatFilesTestCase(TestCase):

--- a/bespin/test_jobtemplate.py
+++ b/bespin/test_jobtemplate.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from unittest import TestCase
 import yaml
 import json
-from bespin.jobtemplate import JobTemplate, JobTemplateLoader, JobOrderWalker, JobOrderFileDetails, \
-    JobOrderFormatFiles
+from bespin.jobtemplate import JobTemplate, JobTemplateLoader, JobOrderWalker, JobOrderFileDetails, JobOrderFormatFiles
 from bespin.exceptions import IncompleteJobTemplateException
+from bespin.dukeds import ProjectDoesNotExistException, FileDoesNotExistException
 from mock import patch, call, Mock
 
 
@@ -89,6 +89,21 @@ class JobTemplateTestCase(TestCase):
                 'class': 'File',
                 'location': 'https://github.com/datafile1.dat'
         }, "URL file paths should not be modified.")
+
+    def test_create_user_job_order_does_not_modify_original(self):
+        job_template = JobTemplate(tag='sometag', name='myjob', fund_code='001', job_order={
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project/somepath.txt'
+            }
+        })
+        job_template.create_user_job_order()
+        self.assertEqual(job_template.job_order, {
+            'myfile': {
+                'class': 'File',
+                'path': 'dds://project/somepath.txt',
+            }
+        })
 
     @patch('bespin.jobtemplate.DDSFileUtil')
     def test_get_dds_files_details(self, mock_dds_file_util):


### PR DESCRIPTION
Instead of performing validation locally send the job order to bespin-api for validation.
Improves handling exceptions received from bespin-api.

Fixes #27