### PR TITLE
Support for validating workflow-version from a direct URL or local file

### DIFF
--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -102,11 +102,12 @@ class WorkflowVersionCommand(object):
         # Create and validate have some common arguments
         for parser in [create_parser, validate_parser]:
             parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
-            parser.add_argument('--type', default='zipped', help='Type of workflow (zipped or packed)')
-            parser.add_argument('--path', required=True, help='Path to the workflow to run (relative path in '
-                                                                   'unzipped archive or #main for packed workflows)')
 
-        # They differ slightly in what version and workflow tag mean,
+        # They differ slightly in how the version and tag arguments are interpreted
+        create_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped or packed)')
+        create_parser.add_argument('--path', required=True, help='Path to the workflow to run (relative path in '
+                                                            'unzipped archive or #main for packed workflows)')
+
         create_parser.add_argument('--version', metavar='VERSION_STRING',
                                      help='Explicit version to use when creating version '
                                           '(otherwise reads from CWL label)')
@@ -123,6 +124,10 @@ class WorkflowVersionCommand(object):
         create_validate_group.add_argument('--no-validate', dest='validate', action='store_false')
         create_parser.set_defaults(validate=True)
 
+        validate_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped, packed, or local)')
+        validate_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
+                                                                 'unzipped archive or #main for packed workflows.'
+                                                                    'Not used for local validation)')
         validate_parser.add_argument('--version', metavar='VERSION_STRING',
                                      help='Explicit version to check when validating')
         validate_parser.add_argument('--workflow-tag', metavar='WORKFLOW_TAG',

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -104,7 +104,8 @@ class WorkflowVersionCommand(object):
             parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
 
         # They differ slightly in how the version and tag arguments are interpreted
-        create_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped or packed)')
+        create_parser.add_argument('--type', default='zipped', help='Type of workflow',
+                                   choices=['zipped','packed'])
         create_parser.add_argument('--path', required=True, help='Path to the workflow to run (relative path in '
                                                             'unzipped archive or #main for packed workflows)')
 
@@ -124,7 +125,8 @@ class WorkflowVersionCommand(object):
         create_validate_group.add_argument('--no-validate', dest='validate', action='store_false')
         create_parser.set_defaults(validate=True)
 
-        validate_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped, packed, or direct)')
+        validate_parser.add_argument('--type', default='zipped', help='Type of workflow',
+                                     choices=['zipped','packed','direct'])
         validate_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
                                                                  'unzipped archive or #main for packed workflows.'
                                                                     'Cannot be used for \'direct\' type)')

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -124,10 +124,10 @@ class WorkflowVersionCommand(object):
         create_validate_group.add_argument('--no-validate', dest='validate', action='store_false')
         create_parser.set_defaults(validate=True)
 
-        validate_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped, packed, or local)')
+        validate_parser.add_argument('--type', default='zipped', help='Type of workflow (zipped, packed, or direct)')
         validate_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
                                                                  'unzipped archive or #main for packed workflows.'
-                                                                    'Not used for local validation)')
+                                                                    'Cannot be used for \'direct\' type)')
         validate_parser.add_argument('--version', metavar='VERSION_STRING',
                                      help='Explicit version to check when validating')
         validate_parser.add_argument('--workflow-tag', metavar='WORKFLOW_TAG',

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -63,9 +63,13 @@ class Commands(object):
 
     def workflow_version_validate(self, url, workflow_type, workflow_path, expected_tag=None,
                                 expected_version=None):
-        #  workflow type 'direct' is a direct URL to a workflow file, it should not have a workflow_path
         if workflow_type == BespinWorkflowLoader.TYPE_DIRECT and workflow_path:
+            # direct type does not use workflow_path
             msg = "Error: Do not provide path for {} workflows".format(BespinWorkflowLoader.TYPE_DIRECT)
+            raise UserInputException(msg)
+        elif workflow_type != BespinWorkflowLoader.TYPE_DIRECT and not workflow_path:
+            # other types require workflow_path
+            msg = "Error: path is required for {} workflows".format(workflow_type)
             raise UserInputException(msg)
         workflow_version = CWLWorkflowVersion(url, workflow_type, workflow_path, validate=True)
         validated = workflow_version.validate_workflow(expected_tag, expected_version)

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -63,10 +63,10 @@ class Commands(object):
 
     def workflow_version_validate(self, url, workflow_type, workflow_path, expected_tag=None,
                                 expected_version=None):
-        # local workflow type is a direct URL to a workflow file, it should not have a workflow_path
-        if workflow_type == BespinWorkflowLoader.TYPE_LOCAL and workflow_path:
-            msg = "Error: Do not provide path for {} workflows".format(BespinWorkflowLoader.TYPE_LOCAL)
-            raise  UserInputException(msg)
+        #  workflow type 'direct' is a direct URL to a workflow file, it should not have a workflow_path
+        if workflow_type == BespinWorkflowLoader.TYPE_DIRECT and workflow_path:
+            msg = "Error: Do not provide path for {} workflows".format(BespinWorkflowLoader.TYPE_DIRECT)
+            raise UserInputException(msg)
         workflow_version = CWLWorkflowVersion(url, workflow_type, workflow_path, validate=True)
         validated = workflow_version.validate_workflow(expected_tag, expected_version)
         print("Validated {} as '{}/{}'".format(url, validated.tag, validated.version))

--- a/bespin/commands.py
+++ b/bespin/commands.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from bespin.config import ConfigFile
 from bespin.api import BespinApi
-from bespin.workflow import CWLWorkflowVersion
+from bespin.workflow import CWLWorkflowVersion, BespinWorkflowLoader
 from bespin.jobtemplate import JobTemplateLoader
 from bespin.exceptions import WorkflowConfigurationNotFoundException, UserInputException
 from tabulate import tabulate
@@ -63,6 +63,10 @@ class Commands(object):
 
     def workflow_version_validate(self, url, workflow_type, workflow_path, expected_tag=None,
                                 expected_version=None):
+        # local workflow type is a direct URL to a workflow file, it should not have a workflow_path
+        if workflow_type == BespinWorkflowLoader.TYPE_LOCAL and workflow_path:
+            msg = "Error: Do not provide path for {} workflows".format(BespinWorkflowLoader.TYPE_LOCAL)
+            raise  UserInputException(msg)
         workflow_version = CWLWorkflowVersion(url, workflow_type, workflow_path, validate=True)
         validated = workflow_version.validate_workflow(expected_tag, expected_version)
         print("Validated {} as '{}/{}'".format(url, validated.tag, validated.version))

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -113,6 +113,18 @@ class ArgParserTestCase(TestCase):
             expected_version='vE.X.P'
         )
 
+    def test_workflow_versions_validate_local_without_path(self):
+        self.arg_parser.parse_and_run_commands(['workflow-version', 'validate',
+                                                '--url', 'localurl',
+                                                '--type', 'local'])
+        self.target_object.workflow_version_validate.assert_called_with(
+            url="localurl",
+            workflow_type="local",
+            workflow_path=None,
+            expected_tag=None,
+            expected_version=None
+        )
+
     def test_workflow_config_list(self):
         self.arg_parser.parse_and_run_commands(["workflow-config", "list"])
         self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -113,13 +113,13 @@ class ArgParserTestCase(TestCase):
             expected_version='vE.X.P'
         )
 
-    def test_workflow_versions_validate_local_without_path(self):
+    def test_workflow_versions_validate_direct_without_path(self):
         self.arg_parser.parse_and_run_commands(['workflow-version', 'validate',
-                                                '--url', 'localurl',
-                                                '--type', 'local'])
+                                                '--url', 'file:///direct.cwl',
+                                                '--type', 'direct'])
         self.target_object.workflow_version_validate.assert_called_with(
-            url="localurl",
-            workflow_type="local",
+            url="file:///direct.cwl",
+            workflow_type="direct",
             workflow_path=None,
             expected_tag=None,
             expected_version=None

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -264,11 +264,11 @@ class CommandsTestCase(TestCase):
     @patch('bespin.commands.BespinApi')
     @patch('bespin.commands.print')
     @patch('bespin.commands.CWLWorkflowVersion')
-    def test_workflow_version_validate_local_raises_if_path(self, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
+    def test_workflow_version_validate_direct_raises_if_path(self, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
         commands = Commands(self.version_str, self.user_agent_str)
         # mock_cwl_workflow_version.return_value.validate_workflow.return_value = Mock(tag='workflow-tag',version='v1.2.3')
         with self.assertRaises(UserInputException) as context:
-            commands.workflow_version_validate(url='someurl', workflow_type='local', workflow_path='extracted/workflow.cwl',
+            commands.workflow_version_validate(url='someurl', workflow_type='direct', workflow_path='extracted/workflow.cwl',
                                                expected_tag='workflow-tag', expected_version='v1.2.3')
         self.assertIn('Do not provide path', str(context.exception))
 

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -246,11 +246,9 @@ class CommandsTestCase(TestCase):
             call("Created workflow version 7.")
         ])
 
-    @patch('bespin.commands.ConfigFile')
-    @patch('bespin.commands.BespinApi')
     @patch('bespin.commands.print')
     @patch('bespin.commands.CWLWorkflowVersion')
-    def test_workflow_version_validate(self, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
+    def test_workflow_version_validate(self, mock_cwl_workflow_version, mock_print):
         commands = Commands(self.version_str, self.user_agent_str)
         mock_cwl_workflow_version.return_value.validate_workflow.return_value = Mock(tag='workflow-tag',version='v1.2.3')
         commands.workflow_version_validate(url='someurl', workflow_type='zipped', workflow_path='extracted/workflow.cwl',
@@ -260,13 +258,8 @@ class CommandsTestCase(TestCase):
             call("Validated someurl as 'workflow-tag/v1.2.3'")
         ])
 
-    @patch('bespin.commands.ConfigFile')
-    @patch('bespin.commands.BespinApi')
-    @patch('bespin.commands.print')
-    @patch('bespin.commands.CWLWorkflowVersion')
-    def test_workflow_version_validate_direct_raises_if_path(self, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
+    def test_workflow_version_validate_direct_raises_if_path(self):
         commands = Commands(self.version_str, self.user_agent_str)
-        # mock_cwl_workflow_version.return_value.validate_workflow.return_value = Mock(tag='workflow-tag',version='v1.2.3')
         with self.assertRaises(UserInputException) as context:
             commands.workflow_version_validate(url='someurl', workflow_type='direct', workflow_path='extracted/workflow.cwl',
                                                expected_tag='workflow-tag', expected_version='v1.2.3')

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -265,6 +265,13 @@ class CommandsTestCase(TestCase):
                                                expected_tag='workflow-tag', expected_version='v1.2.3')
         self.assertIn('Do not provide path', str(context.exception))
 
+    def test_workflow_version_validate_raises_without_path(self):
+        commands = Commands(self.version_str, self.user_agent_str)
+        with self.assertRaises(UserInputException) as context:
+            commands.workflow_version_validate(url='someurl', workflow_type='not-direct', workflow_path=None,
+                                               expected_tag='workflow-tag', expected_version='v1.2.3')
+        self.assertIn('path is required', str(context.exception))
+
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
     @patch('bespin.commands.WorkflowConfigurationsList')

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -260,6 +260,17 @@ class CommandsTestCase(TestCase):
             call("Validated someurl as 'workflow-tag/v1.2.3'")
         ])
 
+    @patch('bespin.commands.ConfigFile')
+    @patch('bespin.commands.BespinApi')
+    @patch('bespin.commands.print')
+    @patch('bespin.commands.CWLWorkflowVersion')
+    def test_workflow_version_validate_local_raises_if_path(self, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
+        commands = Commands(self.version_str, self.user_agent_str)
+        # mock_cwl_workflow_version.return_value.validate_workflow.return_value = Mock(tag='workflow-tag',version='v1.2.3')
+        with self.assertRaises(UserInputException) as context:
+            commands.workflow_version_validate(url='someurl', workflow_type='local', workflow_path='extracted/workflow.cwl',
+                                               expected_tag='workflow-tag', expected_version='v1.2.3')
+        self.assertIn('Do not provide path', str(context.exception))
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')

--- a/bespin/test_workflow.py
+++ b/bespin/test_workflow.py
@@ -22,10 +22,10 @@ class BespinWorkflowLoaderTestCase(TestCase):
                                                        url='http://example.com/zipped.zip',
                                                        workflow_type=BespinWorkflowLoader.TYPE_ZIPPED,
                                                        workflow_path='unzipped/workflow.cwl')
-        self.local_workflow_version = create_autospec(CWLWorkflowVersion,
-                                                      url='file:///local/local.cwl',
-                                                      workflow_type=BespinWorkflowLoader.TYPE_LOCAL,
-                                                      workflow_path=None)
+        self.direct_workflow_version = create_autospec(CWLWorkflowVersion,
+                                                       url='file:///direct/direct.cwl',
+                                                       workflow_type=BespinWorkflowLoader.TYPE_DIRECT,
+                                                       workflow_path=None)
 
     def setup_mkdtemp(self, mock_mkdtemp):
         mock_mkdtemp.return_value = '/tmpdir'
@@ -62,9 +62,9 @@ class BespinWorkflowLoaderTestCase(TestCase):
         self.assertEqual(mock_urlretrieve.call_args, call(self.zipped_workflow_version.url, loader.download_path))
 
     @patch('bespin.workflow.urlretrieve')
-    def test__no_download_local(self, mock_urlretriefve, mock_mkdtemp):
+    def test__no_download_direct(self, mock_urlretriefve, mock_mkdtemp):
         self.setup_mkdtemp(mock_mkdtemp)
-        loader = BespinWorkflowLoader(self.local_workflow_version)
+        loader = BespinWorkflowLoader(self.direct_workflow_version)
         loader._download_workflow()
         self.assertFalse(mock_urlretriefve.called)
 
@@ -106,11 +106,11 @@ class BespinWorkflowLoaderTestCase(TestCase):
         tool_path = loader._get_tool_path()
         self.assertEqual(tool_path, '/tmpdir/unzipped/workflow.cwl')
 
-    def test__get_tool_path_local(self, mock_mkdtemp):
+    def test__get_tool_path_direct(self, mock_mkdtemp):
         self.setup_mkdtemp(mock_mkdtemp)
-        loader = BespinWorkflowLoader(self.local_workflow_version)
+        loader = BespinWorkflowLoader(self.direct_workflow_version)
         tool_path = loader._get_tool_path()
-        self.assertEqual(tool_path, 'file:///local/local.cwl')
+        self.assertEqual(tool_path, 'file:///direct/direct.cwl')
 
     def test__get_tool_path_raises(self, mock_mkdtemp):
         self.setup_mkdtemp(mock_mkdtemp)
@@ -128,9 +128,9 @@ class BespinWorkflowLoaderTestCase(TestCase):
         self.assertEqual(mock_rmtree.call_args, call(loader.download_dir))
 
     @patch('bespin.workflow.shutil.rmtree')
-    def test__cleanup_local(self, mock_rmtree, mock_mkdtemp):
+    def test__cleanup_direct(self, mock_rmtree, mock_mkdtemp):
         self.setup_mkdtemp(mock_mkdtemp)
-        loader = BespinWorkflowLoader(self.local_workflow_version)
+        loader = BespinWorkflowLoader(self.direct_workflow_version)
         loader._cleanup()
         self.assertFalse(mock_rmtree.called)
 

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -23,7 +23,7 @@ class BespinWorkflowLoader(object):
 
     TYPE_PACKED = 'packed'
     TYPE_ZIPPED = 'zipped'
-    TYPE_LOCAL = 'local'
+    TYPE_DIRECT = 'direct'
 
     def __init__(self, workflow_version):
         """
@@ -48,7 +48,7 @@ class BespinWorkflowLoader(object):
         return loaded
 
     def _download_workflow(self):
-        if not self.workflow_version.workflow_type == self.TYPE_LOCAL:
+        if not self.workflow_version.workflow_type == self.TYPE_DIRECT:
             urlretrieve(self.workflow_version.url, self.download_path)
 
     def _handle_download(self):
@@ -78,7 +78,7 @@ class BespinWorkflowLoader(object):
             tool_path = self.download_path + '#main'
         elif self.workflow_version.workflow_type == self.TYPE_ZIPPED:
             tool_path = os.path.join(self.download_dir, self.workflow_version.workflow_path)
-        elif self.workflow_version.workflow_type == self.TYPE_LOCAL:
+        elif self.workflow_version.workflow_type == self.TYPE_DIRECT:
             tool_path = self.workflow_version.url
         else:
             raise InvalidWorkflowFileException(
@@ -89,7 +89,7 @@ class BespinWorkflowLoader(object):
         """
         Remove temporary download items
         """
-        if not self.workflow_version.workflow_type == self.TYPE_LOCAL:
+        if not self.workflow_version.workflow_type == self.TYPE_DIRECT:
             shutil.rmtree(self.download_dir)
 
 

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -23,6 +23,7 @@ class BespinWorkflowLoader(object):
 
     TYPE_PACKED = 'packed'
     TYPE_ZIPPED = 'zipped'
+    TYPE_LOCAL = 'local'
 
     def __init__(self, workflow_version):
         """
@@ -47,7 +48,8 @@ class BespinWorkflowLoader(object):
         return loaded
 
     def _download_workflow(self):
-        urlretrieve(self.workflow_version.url, self.download_path)
+        if not self.workflow_version.workflow_type == self.TYPE_LOCAL:
+            urlretrieve(self.workflow_version.url, self.download_path)
 
     def _handle_download(self):
         if self.workflow_version.workflow_type == self.TYPE_ZIPPED:
@@ -76,6 +78,8 @@ class BespinWorkflowLoader(object):
             tool_path = self.download_path + '#main'
         elif self.workflow_version.workflow_type == self.TYPE_ZIPPED:
             tool_path = os.path.join(self.download_dir, self.workflow_version.workflow_path)
+        elif self.workflow_version.workflow_type == self.TYPE_LOCAL:
+            tool_path = self.workflow_version.url
         else:
             raise InvalidWorkflowFileException(
                 'Workflow type {} is not supported'.format(self.workflow_version.workflow_type))
@@ -85,7 +89,8 @@ class BespinWorkflowLoader(object):
         """
         Remove temporary download items
         """
-        shutil.rmtree(self.download_dir)
+        if not self.workflow_version.workflow_type == self.TYPE_LOCAL:
+            shutil.rmtree(self.download_dir)
 
 
 class BespinWorkflowValidator(object):

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -31,9 +31,10 @@ class BespinWorkflowLoader(object):
         :param workflow_version: CWLWorkflowVersion containing the workflow_type and workflow_path
         :param download_dir: Optional path to a download directory. If None, a temp directory is used
         """
-        self.download_dir = tempfile.mkdtemp()
         self.workflow_version = workflow_version
-        self.download_path = os.path.join(self.download_dir, os.path.basename(workflow_version.url))
+        if not self.workflow_version.workflow_type == self.TYPE_DIRECT:
+            self.download_dir = tempfile.mkdtemp()
+            self.download_path = os.path.join(self.download_dir, os.path.basename(workflow_version.url))
 
     def load(self):
         """


### PR DESCRIPTION
Adds support for validating workflow files from a URL (can be local file on disk without zipping or packing).

Usage:
```
bespin workflow-version validate --type direct --url file:///local/path/to/workflow.cwl
```

When validating direct, `--path` must not be specified.