### PR TITLE
Add tool-details command to extract/upload software details

### DIFF
--- a/bespin/api.py
+++ b/bespin/api.py
@@ -110,7 +110,7 @@ class BespinApi(object):
         url = '/workflow-versions/?version={}&workflow__tag={}'.format(version, tag)
         workflow_versions = self._get_request(url)
         if not workflow_versions :
-            raise WorkflowNotFound("No workflow version found with version/tag {}/{}".format(version, tag))
+            raise WorkflowNotFound("No workflow version found matching {}/{}".format(tag, version))
         return workflow_versions[0]
 
     def workflow_versions_post(self, workflow, version, workflow_type, description, workflow_path, url, version_info_url, fields):

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -106,8 +106,8 @@ class BespinApi(object):
             url += '?workflow__tag={}'.format(workflow_tag)
         return self._get_request(url)
 
-    def workflow_version_find_by_version_tag(self, version, tag):
-        url = '/workflow-versions/?version={}&workflow__tag={}'.format(version, tag)
+    def workflow_version_find_by_tag_version(self, tag, version):
+        url = '/workflow-versions/?workflow__tag={}&version={}'.format(tag, version)
         workflow_versions = self._get_request(url)
         if not workflow_versions :
             raise WorkflowNotFound("No workflow version found matching {}/{}".format(tag, version))

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -129,7 +129,7 @@ class BespinApi(object):
     def workflow_version_get(self, workflow_version):
         return self._get_request('/workflow-versions/{}/'.format(workflow_version))
 
-    def workflow_tool_details_post(self, workflow_version_id, tool_details):
+    def workflow_version_tool_details_post(self, workflow_version_id, tool_details):
         data = {
             "workflow_version": workflow_version_id,
             "details": tool_details

--- a/bespin/api.py
+++ b/bespin/api.py
@@ -106,6 +106,13 @@ class BespinApi(object):
             url += '?workflow__tag={}'.format(workflow_tag)
         return self._get_request(url)
 
+    def workflow_version_find_by_version_tag(self, version, tag):
+        url = '/workflow-versions/?version={}&workflow__tag={}'.format(version, tag)
+        workflow_versions = self._get_request(url)
+        if not workflow_versions :
+            raise WorkflowNotFound("No workflow version found with version/tag {}/{}".format(version, tag))
+        return workflow_versions[0]
+
     def workflow_versions_post(self, workflow, version, workflow_type, description, workflow_path, url, version_info_url, fields):
         data = {
             "workflow": workflow,
@@ -121,6 +128,13 @@ class BespinApi(object):
 
     def workflow_version_get(self, workflow_version):
         return self._get_request('/workflow-versions/{}/'.format(workflow_version))
+
+    def workflow_tool_details_post(self, workflow_version_id, tool_details):
+        data = {
+            "workflow_version": workflow_version_id,
+            "details": tool_details
+        }
+        return self._post_request('/admin/workflow-version-tool-details/', data)
 
     def workflow_configurations_list(self, tag=None, workflow=None, workflow_tag=None):
         url = '/workflow-configurations/'

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -164,14 +164,25 @@ class ToolDetailsCommand(object):
         self.target = target
 
     def add_actions(self, subparsers):
-        create_parser = subparsers.add_parser('create', description='Create tool details')
-        create_parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
-        create_parser.add_argument('--type', default='zipped', help='Type of workflow',
-                                         choices=['zipped','packed','direct'])
-        create_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
-                                                                  'unzipped archive or #main for packed workflows.'
-                                                                  'Cannot be used for \'direct\' type)')
+        create_parser = subparsers.add_parser('create', description='Extract tool details (e.g. software versions) '
+                                                                    'from a workflow and upload them')
+        preview_parser = subparsers.add_parser('preview', description='Extract tool details (e.g. software versions) '
+                                                                      'from a workflow and display them')
+        for parser in [create_parser, preview_parser, ]:
+            parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
+            parser.add_argument('--type', default='zipped', help='Type of workflow',
+                                choices=['zipped','packed','direct'])
+            parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
+                                                               'unzipped archive or #main for packed workflows. '
+                                                               'Cannot be used for \'direct\' type)')
+            # Also add override tag/verison to create
         create_parser.set_defaults(func=self._create)
+        preview_parser.set_defaults(func=self._preview)
+
+    def _preview(self, args):
+        self.target.workflow_tool_details_preview(url=args.url,
+                                                  workflow_type=args.type,
+                                                  workflow_path=args.path)
 
     def _create(self, args):
         self.target.workflow_tool_details_create(url=args.url,

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -164,10 +164,11 @@ class ToolDetailsCommand(object):
         self.target = target
 
     def add_actions(self, subparsers):
-        create_parser = subparsers.add_parser('create', description='Extract tool details (e.g. software versions) '
-                                                                    'from a workflow and upload them')
-        preview_parser = subparsers.add_parser('preview', description='Extract tool details (e.g. software versions) '
-                                                                      'from a workflow and display them')
+        create_parser = subparsers.add_parser('create', description='Create new workflow version tool details for '
+                                                                    'a workflow version, parsing them from a CWL '
+                                                                    'workflow')
+        preview_parser = subparsers.add_parser('preview', description='Parse workflow version tool details from a CWL '
+                                                                      'workflow and display them in JSON format')
         for parser in [create_parser, preview_parser, ]:
             parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
             parser.add_argument('--type', default='zipped', help='Type of workflow',
@@ -175,19 +176,26 @@ class ToolDetailsCommand(object):
             parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
                                                                'unzipped archive or #main for packed workflows. '
                                                                'Cannot be used for \'direct\' type)')
-            # Also add override tag/verison to create
+        create_parser.add_argument('--version', metavar='VERSION_STRING',
+                                   help='Explicit version to use when looking up workflow version '
+                                        '(otherwise reads from CWL label)')
+        create_parser.add_argument('--workflow-tag', metavar='WORKFLOW_TAG',
+                                   help='Explicit workflow tag to use when looking up workflow version '
+                                        '(otherwise reads from CWL label)')
         create_parser.set_defaults(func=self._create)
         preview_parser.set_defaults(func=self._preview)
 
     def _preview(self, args):
-        self.target.workflow_tool_details_preview(url=args.url,
-                                                  workflow_type=args.type,
-                                                  workflow_path=args.path)
+        self.target.workflow_version_tool_details_preview(url=args.url,
+                                                          workflow_type=args.type,
+                                                          workflow_path=args.path)
 
     def _create(self, args):
-        self.target.workflow_tool_details_create(url=args.url,
-                                                 workflow_type=args.type,
-                                                 workflow_path=args.path)
+        self.target.workflow_version_tool_details_create(url=args.url,
+                                                         workflow_type=args.type,
+                                                         workflow_path=args.path,
+                                                         override_version=args.version,
+                                                         override_tag=args.workflow_tag)
 
 
 class WorkflowConfigCommand(object):

--- a/bespin/argparser.py
+++ b/bespin/argparser.py
@@ -22,6 +22,7 @@ class ArgParser(object):
     def _add_commands_to_parser(self):
         self._add_command(WorkflowCommand)
         self._add_command(WorkflowVersionCommand)
+        self._add_command(ToolDetailsCommand)
         self._add_command(WorkflowConfigCommand)
         self._add_command(ShareGroupCommand)
         self._add_command(JobConfigCommand)
@@ -128,7 +129,7 @@ class WorkflowVersionCommand(object):
         validate_parser.add_argument('--type', default='zipped', help='Type of workflow',
                                      choices=['zipped','packed','direct'])
         validate_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
-                                                                 'unzipped archive or #main for packed workflows.'
+                                                                    'unzipped archive or #main for packed workflows.'
                                                                     'Cannot be used for \'direct\' type)')
         validate_parser.add_argument('--version', metavar='VERSION_STRING',
                                      help='Explicit version to check when validating')
@@ -153,6 +154,29 @@ class WorkflowVersionCommand(object):
                                               workflow_path=args.path,
                                               expected_tag=args.workflow_tag,
                                               expected_version=args.version)
+
+
+class ToolDetailsCommand(object):
+    name = "tool-details"
+    description = "workflow version tool details commands"
+
+    def __init__(self, target):
+        self.target = target
+
+    def add_actions(self, subparsers):
+        create_parser = subparsers.add_parser('create', description='Create tool details')
+        create_parser.add_argument('--url', required=True, help='URL that specifies the CWL workflow')
+        create_parser.add_argument('--type', default='zipped', help='Type of workflow',
+                                         choices=['zipped','packed','direct'])
+        create_parser.add_argument('--path', required=False, help='Path to the workflow to run (relative path in '
+                                                                  'unzipped archive or #main for packed workflows.'
+                                                                  'Cannot be used for \'direct\' type)')
+        create_parser.set_defaults(func=self._create)
+
+    def _create(self, args):
+        self.target.workflow_tool_details_create(url=args.url,
+                                                 workflow_type=args.type,
+                                                 workflow_path=args.path)
 
 
 class WorkflowConfigCommand(object):

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -140,29 +140,29 @@ class BespinApiTestCase(TestCase):
                                              headers=self.expected_headers)
 
     @patch('bespin.api.requests')
-    def test_workflow_version_find_by_version_tag(self, mock_requests):
+    def test_workflow_version_find_by_tag_version(self, mock_requests):
         mock_response = Mock(status_code=200)
         mock_response.json.return_value = ['filtered',]
         mock_requests.get.return_value = mock_response
 
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
-        item = api.workflow_version_find_by_version_tag('v3','exomeseq')
+        item = api.workflow_version_find_by_tag_version('exomeseq', 'v3')
 
         self.assertEqual(item, 'filtered')
-        mock_requests.get.assert_called_with('someurl/workflow-versions/?version=v3&workflow__tag=exomeseq',
+        mock_requests.get.assert_called_with('someurl/workflow-versions/?workflow__tag=exomeseq&version=v3',
                                              headers=self.expected_headers)
 
     @patch('bespin.api.requests')
-    def test_workflow_version_find_by_version_tag_raise_empty(self, mock_requests):
+    def test_workflow_version_find_by_tag_version_raises_empty(self, mock_requests):
         mock_response = Mock(status_code=200)
         mock_response.json.return_value = []
         mock_requests.get.return_value = mock_response
 
         api = BespinApi(config=self.mock_config, user_agent_str=self.mock_user_agent_str)
         with self.assertRaises(WorkflowNotFound) as context:
-            api.workflow_version_find_by_version_tag('v3','exomeseq')
+            api.workflow_version_find_by_tag_version('exomeseq', 'v3')
         self.assertIn('No workflow version found matching exomeseq/v3', str(context.exception))
-        mock_requests.get.assert_called_with('someurl/workflow-versions/?version=v3&workflow__tag=exomeseq',
+        mock_requests.get.assert_called_with('someurl/workflow-versions/?workflow__tag=exomeseq&version=v3',
                                              headers=self.expected_headers)
 
     @patch('bespin.api.requests')

--- a/bespin/test_api.py
+++ b/bespin/test_api.py
@@ -138,6 +138,8 @@ class BespinApiTestCase(TestCase):
         self.assertEqual(items, ['workflowversion1', 'workflowversion2'])
         mock_requests.get.assert_called_with('someurl/workflow-versions/?workflow__tag=exomeseq',
                                              headers=self.expected_headers)
+    def test_workflow_version_find_by_version_tag(self):
+        self.fail('not yet implemented')
 
     @patch('bespin.api.requests')
     def test_workflow_version_get(self, mock_requests):
@@ -180,6 +182,9 @@ class BespinApiTestCase(TestCase):
         }
         mock_requests.post.assert_called_with('someurl/admin/workflow-versions/', headers=self.expected_headers,
                                               json=expected_post_payload)
+
+    def test_workflow_version_tool_details_post(self):
+        self.fail('not yet implemented')
 
     @patch('bespin.api.requests')
     def test_stage_group_post(self, mock_requests):

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -125,6 +125,15 @@ class ArgParserTestCase(TestCase):
             expected_version=None
         )
 
+    def test_workflow_version_tool_details_create(self):
+        self.fail('not yet implemented')
+
+    def test_workflow_version_tool_details_create_with_overrides(self):
+        self.fail('not yet implemented')
+
+    def test_workflow_version_tool_details_preview(self):
+        self.fail('not yet implemented')
+
     def test_workflow_config_list(self):
         self.arg_parser.parse_and_run_commands(["workflow-config", "list"])
         self.target_object.workflow_configs_list.assert_called_with(workflow_tag=None)

--- a/bespin/test_argparse.py
+++ b/bespin/test_argparse.py
@@ -125,14 +125,44 @@ class ArgParserTestCase(TestCase):
             expected_version=None
         )
 
-    def test_workflow_version_tool_details_create(self):
-        self.fail('not yet implemented')
+    def test_workflow_version_tool_details_create_without_override(self):
+        self.arg_parser.parse_and_run_commands(['tool-details', 'create',
+                                                '--url', 'someurl',
+                                                '--type', 'zipped',
+                                                '--path', 'extracted/file.cwl'])
+        self.target_object.workflow_version_tool_details_create.assert_called_with(
+            url='someurl',
+            workflow_type='zipped',
+            workflow_path='extracted/file.cwl',
+            override_tag=None,
+            override_version=None
+        )
 
-    def test_workflow_version_tool_details_create_with_overrides(self):
-        self.fail('not yet implemented')
+    def test_workflow_version_tool_details_create_with_override(self):
+        self.arg_parser.parse_and_run_commands(['tool-details', 'create',
+                                                '--url', 'someurl',
+                                                '--type', 'zipped',
+                                                '--path', 'extracted/file.cwl',
+                                                '--workflow-tag', 'tag',
+                                                '--version', 'v3'])
+        self.target_object.workflow_version_tool_details_create.assert_called_with(
+            url='someurl',
+            workflow_type='zipped',
+            workflow_path='extracted/file.cwl',
+            override_tag='tag',
+            override_version='v3'
+        )
 
     def test_workflow_version_tool_details_preview(self):
-        self.fail('not yet implemented')
+        self.arg_parser.parse_and_run_commands(['tool-details', 'preview',
+                                                '--url', 'preview-url',
+                                                '--type', 'zipped',
+                                                '--path', 'extracted/file.cwl'])
+        self.target_object.workflow_version_tool_details_preview.assert_called_with(
+            url='preview-url',
+            workflow_type='zipped',
+            workflow_path='extracted/file.cwl',
+        )
 
     def test_workflow_config_list(self):
         self.arg_parser.parse_and_run_commands(["workflow-config", "list"])

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -272,11 +272,36 @@ class CommandsTestCase(TestCase):
                                                expected_tag='workflow-tag', expected_version='v1.2.3')
         self.assertIn('path is required', str(context.exception))
 
-    def test_workflow_version_tool_details_preview(self):
-        self.fail('not yet implemented')
+    @patch('bespin.commands.print')
+    @patch('bespin.commands.json')
+    @patch('bespin.commands.CWLWorkflowVersion')
+    @patch('bespin.commands.ToolDetails')
+    def test_workflow_version_tool_details_preview(self, mock_tool_details, mock_cwl_workflow_version, mock_json, mock_print):
+        commands = Commands(self.version_str, self.user_agent_str)
+        mock_cwl_workflow_version.return_value.validate_workflow.return_value = Mock(tag='workflow-tag',version='v1.2.3')
+        commands.workflow_version_tool_details_preview(url='someurl', workflow_type='zipped', workflow_path='extracted/workflow.cwl')
+        mock_cwl_workflow_version.assert_called_with('someurl','zipped','extracted/workflow.cwl',
+                                                     override_tag=None, override_version=None, validate=False)
+        mock_tool_details.assert_called_with(mock_cwl_workflow_version.return_value)
+        mock_json.dumps.assert_called_with(mock_tool_details.return_value.contents, indent=2)
+        mock_print.assert_called_with(mock_json.dumps.return_value)
 
-    def test_workflow_version_tool_details_create(self):
-        self.fail('not yet implemented')
+    @patch('bespin.commands.ConfigFile')
+    @patch('bespin.commands.BespinApi')
+    @patch('bespin.commands.print')
+    @patch('bespin.commands.CWLWorkflowVersion')
+    @patch('bespin.commands.ToolDetails')
+    def test_workflow_version_tool_details_create(self, mock_tool_details, mock_cwl_workflow_version, mock_print, mock_bespin_api, mock_config_file):
+        commands = Commands(self.version_str, self.user_agent_str)
+        mock_create = mock_tool_details.return_value.create
+        mock_create.return_value = {'id': '5'}
+        commands.workflow_version_tool_details_create(url='someurl', workflow_type='zipped',
+                                                      workflow_path='extracted/workflow.cwl', override_tag='tagg',
+                                                      override_version='v1')
+        mock_cwl_workflow_version.assert_called_with('someurl','zipped','extracted/workflow.cwl',
+                                                     override_tag='tagg', override_version='v1', validate=False)
+        mock_create.assert_called_with(mock_bespin_api.return_value)
+        mock_print.assert_called_with("Created workflow version tool details 5.")
 
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')

--- a/bespin/test_commands.py
+++ b/bespin/test_commands.py
@@ -272,6 +272,12 @@ class CommandsTestCase(TestCase):
                                                expected_tag='workflow-tag', expected_version='v1.2.3')
         self.assertIn('path is required', str(context.exception))
 
+    def test_workflow_version_tool_details_preview(self):
+        self.fail('not yet implemented')
+
+    def test_workflow_version_tool_details_create(self):
+        self.fail('not yet implemented')
+
     @patch('bespin.commands.ConfigFile')
     @patch('bespin.commands.BespinApi')
     @patch('bespin.commands.WorkflowConfigurationsList')

--- a/bespin/test_config.py
+++ b/bespin/test_config.py
@@ -20,14 +20,17 @@ class ConfigFileTestCase(TestCase):
         config_file.write_config.assert_not_called()
 
     @patch('bespin.config.os')
-    def test_read_or_create_config_file_doesnt_exist(self, mock_os):
+    @patch('builtins.print')
+    def test_read_or_create_config_file_doesnt_exist(self, mock_print, mock_os):
         config_file = ConfigFile(filename='/tmp/test.yml')
         config_file.read_config = Mock()
         config_file.write_config = Mock()
         config_file._prompt_user_for_token = Mock()
 
         mock_os.path.exists.return_value = False
+        self.assertFalse(mock_print.called)
         config = config_file.read_or_create_config()
+        self.assertTrue(mock_print.called)
 
         self.assertEqual(config.token, config_file._prompt_user_for_token.return_value)
         config_file.read_config.assert_not_called()

--- a/bespin/test_tool_details.py
+++ b/bespin/test_tool_details.py
@@ -1,23 +1,173 @@
 from unittest import TestCase
-from unittest.mock import patch, call, Mock, create_autospec
+from unittest.mock import patch, call, Mock
+
 from bespin.tool_details import DockerToolDetail, SoftwareToolDetail, ToolDetailsBuilder, ToolDetails
 
 
 class DockerToolDetailTestCase(TestCase):
-    def test_something(self):
-        self.fail('not yet implemented')
+    def setUp(self):
+        self.req_dict = {'dockerPull': 'orgname/image:3.2.1'}
+
+    def test_init(self):
+        detail = DockerToolDetail(self.req_dict)
+        self.assertEqual(detail.docker_image_name, self.req_dict['dockerPull'])
+
+    def test_add_info(self):
+        detail = DockerToolDetail(self.req_dict)
+        info_dict = {}
+        detail.add_info(info_dict)
+        self.assertEqual(info_dict['docker'], [{'image_name': 'orgname/image:3.2.1'}])
 
 
 class SoftwareToolDetailTestCase(TestCase):
-    def test_something(self):
-        self.fail('not yet implemented')
+    def setUp(self):
+        self.req_dict = {'packages': [
+            {'package': 'abc-tk',
+             'version': ['1.0'],
+             'https://schema.org/citation': 'https://example.org'},
+            {'package': 'def-tk',
+             'version': ['2.0'],
+             'https://schema.org/citation': 'https://example.com'}
+        ]}
+
+    def test_init(self):
+        detail = SoftwareToolDetail(self.req_dict)
+        self.assertEqual(detail.packages, self.req_dict['packages'])
+
+    def test_add_info(self):
+        detail = SoftwareToolDetail(self.req_dict)
+        info_dict = {}
+        detail.add_info(info_dict)
+        self.assertEqual(info_dict['software'], [
+            {'citation': 'https://example.org', 'package': 'abc-tk', 'versions': ['1.0']},
+            {'citation': 'https://example.com', 'package': 'def-tk', 'versions': ['2.0']},
+        ])
 
 
 class ToolDetailsBuilderTestCase(TestCase):
-    def test_something(self):
-        self.fail('not yet implemented')
+
+    def setUp(self):
+        self.prefix = '/pre/'
+        self.docker_req = {'class': 'DockerRequirement', 'dockerPull': 'orgname/image:1.0'}
+        self.software_req = {'class': 'SoftwareRequirement',
+                             'packages': [
+                                 {'package': 'abc-tk',
+                                  'version': ['1.0'],
+                                  'https://schema.org/citation': 'https://example.org'}
+                             ]}
+
+    def test_init(self):
+        builder = ToolDetailsBuilder(self.prefix)
+        self.assertEqual(builder.prefix, self.prefix)
+        self.assertEqual(builder.details, [])
+
+    def test_accept(self):
+        builder = ToolDetailsBuilder(self.prefix)
+        visitor = Mock()
+        builder.accept(visitor)
+        self.assertEqual(visitor.visit.call_args, call(builder.extract_tool_details))
+
+    def test_tool_exists(self):
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.details = [{'tool_name': 'foo'}]
+        self.assertTrue(builder.tool_exists('foo'))
+        self.assertFalse(builder.tool_exists('bar'))
+
+    @patch('bespin.tool_details.DockerToolDetail')
+    @patch('bespin.tool_details.SoftwareToolDetail')
+    def test_extract_requirements_docker(self, mock_software_tool_detail, mock_docker_tool_detail):
+        tool_info = Mock()
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.extract_requirements([self.docker_req], tool_info)
+        self.assertEqual(mock_docker_tool_detail.call_count, 1)
+        self.assertEqual(mock_software_tool_detail.call_count, 0)
+        self.assertEqual(mock_docker_tool_detail.call_args, call(self.docker_req))
+        self.assertEqual(mock_docker_tool_detail.return_value.add_info.call_args, call(tool_info))
+
+    @patch('bespin.tool_details.DockerToolDetail')
+    @patch('bespin.tool_details.SoftwareToolDetail')
+    def test_extract_requirements_software(self, mock_software_tool_detail, mock_docker_tool_detail):
+        tool_info = Mock()
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.extract_requirements([self.software_req], tool_info)
+        self.assertEqual(mock_software_tool_detail.call_count, 1)
+        self.assertEqual(mock_docker_tool_detail.call_count, 0)
+        self.assertEqual(mock_software_tool_detail.call_args, call(self.software_req))
+        self.assertEqual(mock_software_tool_detail.return_value.add_info.call_args, call(tool_info))
+
+    @patch('bespin.tool_details.DockerToolDetail')
+    @patch('bespin.tool_details.SoftwareToolDetail')
+    def test_extract_requirements_other(self, mock_software_tool_detail, mock_docker_tool_detail):
+        tool_info = Mock()
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.extract_requirements([{'class': 'OtherRequirement'}], tool_info)
+        self.assertEqual(mock_software_tool_detail.call_count, 0)
+        self.assertEqual(mock_docker_tool_detail.call_count, 0)
+
+    def test_extract_tool_details(self):
+        node = {
+            'class': 'CommandLineTool',
+            'id': '/pre/tool.cwl',
+            'requirements': [self.software_req],
+            'hints': [self.docker_req],
+        }
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.extract_tool_details(node)
+        expected_detail = {'tool_name': 'tool.cwl', 'tool_info': {
+            'software': [{'package': 'abc-tk', 'versions': ['1.0'], 'citation': 'https://example.org'}],
+            'docker': [{'image_name': 'orgname/image:1.0'}]}}
+        self.assertIn(expected_detail, builder.details)
+
+    def test_extract_skips_if_exists(self):
+        builder = ToolDetailsBuilder(self.prefix)
+        builder.details = [{'tool_name': 'tool.cwl'}]
+        node = {
+            'class': 'CommandLineTool',
+            'id': '/pre/tool.cwl',
+            'requirements': [self.software_req],
+            'hints': [self.docker_req],
+        }
+        builder.extract_tool_details(node)
+        self.assertEqual(builder.details, [{'tool_name': 'tool.cwl'}])
+
+    def test_build(self):
+        builder = ToolDetailsBuilder(self.prefix)
+        details = {'tool_name': 'tool.cwl', 'tool_info': {
+            'software': [{'package': 'abc-tk', 'versions': ['1.0'], 'citation': 'https://example.org'}],
+            'docker': [{'image_name': 'orgname/image:1.0'}]}}
+        builder.details = [details]
+        built = builder.build()
+        expected_built = [{'tool_name': 'tool.cwl', 'docker_images': ['orgname/image:1.0'],
+                           'packages': [{'package': 'abc-tk', 'versions': ['1.0'], 'citation': 'https://example.org'}]}]
+        self.assertEqual(built, expected_built)
 
 
 class ToolDetailsTestCase(TestCase):
-    def test_something(self):
-        self.fail('not yet implemented')
+    def setUp(self):
+        self.workflow_version = Mock()
+
+    @patch('bespin.tool_details.BespinWorkflowLoader')
+    @patch('bespin.tool_details.BespinWorkflowParser')
+    @patch('bespin.tool_details.ToolDetailsBuilder')
+    def test_init(self, mock_builder, mock_parser, mock_loader):
+        tool_details = ToolDetails(self.workflow_version)
+        self.assertEqual(tool_details.version, mock_parser.return_value.version)
+        self.assertEqual(tool_details.tag, mock_parser.return_value.tag)
+        self.assertEqual(tool_details.contents, mock_builder.return_value.build.return_value)
+        self.assertEqual(mock_loader.call_args, call(self.workflow_version))
+        self.assertEqual(mock_parser.call_args, call(mock_loader.return_value.load.return_value))
+        self.assertEqual(mock_builder.call_args, call(mock_loader.return_value.get_prefix.return_value))
+        self.assertEqual(mock_builder.return_value.accept.call_args, call(mock_parser.return_value.loaded_workflow))
+
+    @patch('bespin.tool_details.BespinWorkflowLoader')
+    @patch('bespin.tool_details.BespinWorkflowParser')
+    @patch('bespin.tool_details.ToolDetailsBuilder')
+    def test_create(self, mock_builder, mock_parser, mock_loader):
+        tool_details = ToolDetails(self.workflow_version)
+        mock_api = Mock()
+        mock_api.workflow_version_find_by_tag_version.return_value = {'id': '56'}
+        result = tool_details.create(mock_api)
+        self.assertEqual(mock_api.workflow_version_find_by_tag_version.call_args,
+                         call(tool_details.tag, tool_details.version))
+        self.assertEqual(mock_api.workflow_version_tool_details_post.call_args, call('56', tool_details.contents))
+        self.assertEqual(result, mock_api.workflow_version_tool_details_post.return_value)

--- a/bespin/test_tool_details.py
+++ b/bespin/test_tool_details.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from unittest.mock import patch, call, Mock, create_autospec
+from bespin.tool_details import DockerToolDetail, SoftwareToolDetail, ToolDetailsBuilder, ToolDetailsExtractor
+
+
+class DockerToolDetailTestCase(TestCase):
+    def test_something(self):
+        self.fail('not yet implemented')
+
+
+class SoftwareToolDetailTestCase(TestCase):
+    def test_something(self):
+        self.fail('not yet implemented')
+
+
+class ToolDetailsBuilderTestCase(TestCase):
+    def test_something(self):
+        self.fail('not yet implemented')
+
+
+class ToolDetailsExtractorTestCase(TestCase):
+    def test_something(self):
+        self.fail('not yet implemented')

--- a/bespin/test_tool_details.py
+++ b/bespin/test_tool_details.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch, call, Mock, create_autospec
-from bespin.tool_details import DockerToolDetail, SoftwareToolDetail, ToolDetailsBuilder, ToolDetailsExtractor
+from bespin.tool_details import DockerToolDetail, SoftwareToolDetail, ToolDetailsBuilder, ToolDetails
 
 
 class DockerToolDetailTestCase(TestCase):
@@ -18,6 +18,6 @@ class ToolDetailsBuilderTestCase(TestCase):
         self.fail('not yet implemented')
 
 
-class ToolDetailsExtractorTestCase(TestCase):
+class ToolDetailsTestCase(TestCase):
     def test_something(self):
         self.fail('not yet implemented')

--- a/bespin/tool_details.py
+++ b/bespin/tool_details.py
@@ -1,5 +1,7 @@
 import os
 from bespin.workflow import BespinWorkflowLoader, BespinWorkflowParser
+
+
 class DockerToolDetail(object):
 
     def __init__(self, req_dict):

--- a/bespin/tool_details.py
+++ b/bespin/tool_details.py
@@ -1,23 +1,44 @@
-import os
+"""
+Classes in this file are designed to extract software package names, versions, Docker images, and web links (citations)
+from the tools included in a parsed and in-memory CWL workflow. It relies heavily on the CWL v1.0 requirements
+documented at https://www.commonwl.org/v1.0/CommandLineTool.html, namely DockerRequirement, SoftwareRequirement,
+and SoftwarePackage
+
+"""
 from bespin.workflow import BespinWorkflowLoader, BespinWorkflowParser
 
 
 class DockerToolDetail(object):
+    """
+    Extracts the Docker image name from a DockerRequirement
+    """
 
     def __init__(self, req_dict):
         self.docker_image_name = req_dict.get('dockerPull')
 
     def add_info(self, info_dict):
+        """
+        Update the provided dictionary with this object's docker image name
+        :param info_dict: A dictionary of tool info to update
+        """
         docker_infos = [{'image_name': self.docker_image_name}]
         info_dict['docker'] = docker_infos
 
 
 class SoftwareToolDetail(object):
+    """
+    Extracts the software package name, versions, and citation link from a SoftwareRequirement
+    """
 
     def __init__(self, req_dict):
         self.packages = req_dict.get('packages')
 
     def add_info(self, info_dict):
+        """
+        Update the provided dictionary with this object's software details
+        :param info_dict: A dictionary of tool info to update
+        :return:
+        """
         software_info = []
         for package in self.packages:
             software_info.append({
@@ -29,6 +50,10 @@ class SoftwareToolDetail(object):
 
 
 class ToolDetailsBuilder(object):
+    """
+    Tallies a list of tool details, using a loaded cwltool workflow's visit() method to pull details out of
+    every node in the workflow graph of class CommandLineTool
+    """
 
     def __init__(self, prefix):
         self.details = []
@@ -42,6 +67,12 @@ class ToolDetailsBuilder(object):
 
     @staticmethod
     def extract_requirements(requirements, tool_info):
+        """
+        Looks through provided list of requirements, extracting tool details based on the requirement class and updating
+        the provided tool_info dictionary
+        :param requirements: list containing dicts where 'class' is 'DockerRequirement' and/or 'SoftwareRequirement'
+        :param tool_info: A dictionary to update with details pulled out of the requirements
+        """
         for req in requirements:
             if req.get('class') == 'DockerRequirement':
                 tool_detail = DockerToolDetail(req)
@@ -51,11 +82,19 @@ class ToolDetailsBuilder(object):
                 tool_detail.add_info(tool_info)
 
     def extract_tool_details(self, node):
+        """
+        Visitor function to handle a node in the CWL workflow graph and update self.details
+        :param node: A CWL object from the graph, that has a 'class' property
+        """
         if node.get('class') == 'CommandLineTool':
+            # The id of a tool is a long URI string prefixed with the workflow's URL at time of loading
+            # For readability, replace that prefix so that
+            #    'file:///tmp/folder1/ba4wt23/workflow-dir/tools/Tool.cwl' can become 'tools/Tool.cwl'
             tool_name = node.get('id').replace(self.prefix, '', 1)
-            if self.tool_exists(tool_name):  # skip if already extracted
+            # Avoid duplicating tools included multiple times in the same workflow
+            if self.tool_exists(tool_name):
                 return
-            tool_info = {} # Need to unique these
+            tool_info = {}
             reqs = node.get('requirements')
             if reqs:
                 self.extract_requirements(reqs, tool_info)
@@ -66,6 +105,10 @@ class ToolDetailsBuilder(object):
                 self.details.append({'tool_name': tool_name, 'tool_info': tool_info})
 
     def build(self):
+        """
+        Provides a simplified details list, restructured from the raw CWL requirements
+        :return: A list of dictionaries, one for each tool in self.details
+        """
         details_list = []
         for detail in self.details:
             tool_name = detail.get('tool_name', '')
@@ -74,7 +117,7 @@ class ToolDetailsBuilder(object):
             software_infos_list = detail.get('tool_info', {}).get('software', {})
             packages_and_versions = []
             for info in software_infos_list:
-                packages_and_versions.append({k: info[k] for k in ['package','versions', 'citation']})
+                packages_and_versions.append({k: info[k] for k in ['package', 'versions', 'citation']})
             tool_detail = {
               'tool_name': tool_name,
               'docker_images': docker_images,
@@ -85,6 +128,9 @@ class ToolDetailsBuilder(object):
 
 
 class ToolDetails(object):
+    """
+    Given a CWLWorkflowVersion, fetch, load, and parse it. Then build a list of tool details from it.
+    """
 
     def __init__(self, workflow_version):
         loader = BespinWorkflowLoader(workflow_version)
@@ -97,7 +143,12 @@ class ToolDetails(object):
         self.contents = builder.build()
 
     def create(self, api):
+        """
+        Look up the WorkflowVersion id by tag/version, then POST tool_details for it using the provided BespinApi
+        :param api: a BespinApi instance
+        :return: response data from the API server
+        """
         # To create a ToolDetails, we must first look up the WorkflowVersion by the tag/version for its id
-        api_workflow_version = api.workflow_version_find_by_version_tag(self.version, self.tag)
+        api_workflow_version = api.workflow_version_find_by_tag_version(self.tag, self.version)
         workflow_version_id = api_workflow_version['id']
         return api.workflow_version_tool_details_post(workflow_version_id, self.contents)

--- a/bespin/tool_details.py
+++ b/bespin/tool_details.py
@@ -1,0 +1,92 @@
+import os
+from bespin.workflow import BespinWorkflowLoader, BespinWorkflowParser
+class DockerToolDetail(object):
+
+    def __init__(self, req_dict):
+        self.docker_image_name = req_dict.get('dockerPull')
+
+    def add_info(self, info_dict):
+        docker_infos = [{'image_name': self.docker_image_name}]
+        info_dict['docker'] = docker_infos
+
+
+class SoftwareToolDetail(object):
+
+    def __init__(self, req_dict):
+        self.packages = req_dict.get('packages')
+
+    def add_info(self, info_dict):
+        software_info = []
+        for package in self.packages:
+            package_info = {}
+            package_info['package'] = package.get('package',)
+            package_info['versions'] = package.get('version', [])
+            package_info['citation'] = package.get('https://schema.org/citation')
+            software_info.append(package_info)
+        info_dict['software'] = software_info
+
+
+class ToolDetailsExtractor(object):
+
+    def __init__(self, prefix):
+        self.details = []
+        self.prefix = prefix
+
+    def accept(self, visitor):
+        visitor.visit(self.extract_tool_details)
+
+    def tool_exists(self, tool_name):
+        return tool_name in [detail['tool_name'] for detail in self.details]
+
+    @staticmethod
+    def extract_requirements(requirements, tool_info):
+        for req in requirements:
+            if req.get('class') == 'DockerRequirement':
+                tool_detail = DockerToolDetail(req)
+                tool_detail.add_info(tool_info)
+            elif req.get('class') == 'SoftwareRequirement':
+                tool_detail = SoftwareToolDetail(req)
+                tool_detail.add_info(tool_info)
+
+    def extract_tool_details(self, node):
+        if node.get('class') == 'CommandLineTool':
+            print('replacing', self.prefix)
+            tool_name = node.get('id').replace(self.prefix, '', 1)
+            if self.tool_exists(tool_name):  # skip if already extracted
+                return
+            tool_info = {} # Need to unique these
+            reqs = node.get('requirements')
+            if reqs:
+                self.extract_requirements(reqs, tool_info)
+            hints = node.get('hints')
+            if hints:
+                self.extract_requirements(hints, tool_info)
+            if tool_info: # only add if we have data
+                self.details.append({'tool_name': tool_name, 'tool_info': tool_info})
+
+    def make_details_list(self):
+        details_list = []
+        for detail in self.details:
+            tool_name = detail.get('tool_name', '')
+            docker_infos_list = detail.get('tool_info', {}).get('docker', {})
+            docker_images = [d.get('image_name','') for d in docker_infos_list]
+            software_infos_list = detail.get('tool_info', {}).get('software', {})
+            packages_and_versions = []
+            for info in software_infos_list:
+                packages_and_versions.append({'package': info.get('package'), 'versions': info.get('versions'), 'citation': info.get('citation')})
+            tool_detail = {
+              'tool_name': tool_name,
+              'docker_images': docker_images,
+              'packages': packages_and_versions,
+            }
+            details_list.append(tool_detail)
+        return details_list
+
+
+def extract_tool_details(workflow_version):
+    loader = BespinWorkflowLoader(workflow_version)
+    parser = BespinWorkflowParser(loader.load())
+    prefix = loader.get_prefix()
+    extractor = ToolDetailsExtractor(prefix)
+    extractor.accept(parser.loaded_workflow)
+    return extractor.make_details_list()

--- a/bespin/tool_details.py
+++ b/bespin/tool_details.py
@@ -5,7 +5,7 @@ documented at https://www.commonwl.org/v1.0/CommandLineTool.html, namely DockerR
 and SoftwarePackage
 
 """
-from bespin.workflow import BespinWorkflowLoader, BespinWorkflowParser
+from bespin.workflow import BespinWorkflowLoader, BespinWorkflowParser, remove_prefix
 
 
 class DockerToolDetail(object):
@@ -88,9 +88,9 @@ class ToolDetailsBuilder(object):
         """
         if node.get('class') == 'CommandLineTool':
             # The id of a tool is a long URI string prefixed with the workflow's URL at time of loading
-            # For readability, replace that prefix so that
+            # For readability, remove that prefix so that
             #    'file:///tmp/folder1/ba4wt23/workflow-dir/tools/Tool.cwl' can become 'tools/Tool.cwl'
-            tool_name = node.get('id').replace(self.prefix, '', 1)
+            tool_name = remove_prefix(node.get('id'), self.prefix)
             # Avoid duplicating tools included multiple times in the same workflow
             if self.tool_exists(tool_name):
                 return

--- a/bespin/tool_details.py
+++ b/bespin/tool_details.py
@@ -84,7 +84,7 @@ class ToolDetailsBuilder(object):
         return details_list
 
 
-class ToolDetailsExtractor(object):
+class ToolDetails(object):
 
     def __init__(self, workflow_version):
         loader = BespinWorkflowLoader(workflow_version)
@@ -94,4 +94,10 @@ class ToolDetailsExtractor(object):
         builder.accept(parser.loaded_workflow)
         self.version = parser.version
         self.tag = parser.tag
-        self.tool_details = builder.build()
+        self.contents = builder.build()
+
+    def create(self, api):
+        # To create a ToolDetails, we must first look up the WorkflowVersion by the tag/version for its id
+        api_workflow_version = api.workflow_version_find_by_version_tag(self.version, self.tag)
+        workflow_version_id = api_workflow_version['id']
+        return api.workflow_version_tool_details_post(workflow_version_id, self.contents)

--- a/bespin/workflow.py
+++ b/bespin/workflow.py
@@ -16,6 +16,12 @@ from bespin.exceptions import InvalidWorkflowFileException
 log = logging.getLogger(__name__)
 
 
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
 class BespinWorkflowLoader(object):
     """
     Downloads, extracts, and loads workflows from a URL - packed or zipped.
@@ -102,8 +108,9 @@ class BespinWorkflowLoader(object):
         :return: str: URI prefix of the workflow that can be stripped off parsed tools
         """
         if self.workflow_version.workflow_type == self.TYPE_DIRECT:
-            # For direct workflows, we just use the directory containing the workflow file
-            workflow_dir = os.path.dirname(self.workflow_version.url)
+            # Direct workflows may be 'file:///path/to/workflow.cwl' or /path/to/workflow.cwl
+            file_path = remove_prefix(self.workflow_version.url, 'file://')
+            workflow_dir = os.path.dirname(file_path)
             prefix = 'file://{}/'.format(os.path.realpath(workflow_dir))
         elif self.workflow_version.workflow_type == self.TYPE_ZIPPED:
             # For zipped workflows we need to determine the absoute path to the unzipped file and get its directory


### PR DESCRIPTION
- Adds commands `bespin tool-details create` and `bespin tool-details preview`
- Both fetch/load/parse a workflow from a URL (zipped/packed/direct) to extract details about software tools included by a workflow, adopting convention similar to `bespin workflow-version create`
- `preview` simply parses the workflow and prints the tool details JSON it would upload, but doesn't make any bespin-api calls
- `create` calls bespin-api to POST extracted details to `/api/v2/admin/workflow-version-tool-details/`
- Adds api method to find a workflow version by its tag and version (Requires https://github.com/Duke-GCB/bespin-api/pull/217)

Related: https://github.com/Duke-GCB/bespin-ui/pull/153 and https://github.com/Duke-GCB/bespin-api/pull/215